### PR TITLE
Fixed terminal copying bug

### DIFF
--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -384,7 +384,6 @@ export class VsCodeIdeUtils {
       // This means there is no terminal open to select text from
       return "";
     }
-    
     // Sometimes the above won't successfully separate by command, so we attempt manually
     const stripNonASCIIAndSpaces = (str: string): string => {
       return str.replace(/[^\x00-\x7F\s]/g, "");
@@ -394,7 +393,9 @@ export class VsCodeIdeUtils {
     if (lastLine) {
       let i = lines.length - 1;
       while (i >= 0) {
+        // Strip non-ASCII characters and spaces from the current line
         const strippedLine = stripNonASCIIAndSpaces(lines[i]);
+        // Check if the stripped current line starts with the last line
         if (strippedLine.startsWith(lastLine)) {
           break;
         }

--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -385,16 +385,17 @@ export class VsCodeIdeUtils {
       return "";
     }
     // Sometimes the above won't successfully separate by command, so we attempt manually
-    const stripNonASCIIAndSpaces = (str: string): string => {
-      return str.replace(/[^\x00-\x7F\s]/g, "");
+    const removeNonASCIIAndTrim= (str: string): string => {
+      str = str.replace(/[^\x00-\x7F\s]/g, "");
+      return str.trim()
     };
     const lines: string[] = terminalContents.split("\n");
-    const lastLine: string | undefined = stripNonASCIIAndSpaces(lines.pop() || "")?.trim();
+    const lastLine: string | undefined = removeNonASCIIAndTrim(lines.pop() || "")?.trim();
     if (lastLine) {
       let i = lines.length - 1;
       while (i >= 0) {
         // Strip non-ASCII characters and spaces from the current line
-        const strippedLine = stripNonASCIIAndSpaces(lines[i]);
+        const strippedLine = removeNonASCIIAndTrim(lines[i]);
         // Check if the stripped current line starts with the last line
         if (strippedLine.startsWith(lastLine)) {
           break;

--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -390,8 +390,8 @@ export class VsCodeIdeUtils {
     const lastLine = lines.pop()?.trim();
     if (lastLine) {
       let i = lines.length - 1;
-      while (i >= 0 && !lines[i].trim().startsWith(lastLine)) i--;
-      terminalContents = lines.slice(i).join("\n");
+      while (i >= 0 && !(lines[i].trim().includes(lastLine) || lastLine.includes(lines[i].trim()))) i--;
+      terminalContents = i === -1 ? lines.join("\n") : lines.slice(i).join("\n");
     }
 
     return terminalContents;

--- a/extensions/vscode/src/util/ideUtils.ts
+++ b/extensions/vscode/src/util/ideUtils.ts
@@ -384,16 +384,24 @@ export class VsCodeIdeUtils {
       // This means there is no terminal open to select text from
       return "";
     }
-
+    
     // Sometimes the above won't successfully separate by command, so we attempt manually
-    const lines = terminalContents.split("\n");
-    const lastLine = lines.pop()?.trim();
+    const stripNonASCIIAndSpaces = (str: string): string => {
+      return str.replace(/[^\x00-\x7F\s]/g, "");
+    };
+    const lines: string[] = terminalContents.split("\n");
+    const lastLine: string | undefined = stripNonASCIIAndSpaces(lines.pop() || "")?.trim();
     if (lastLine) {
       let i = lines.length - 1;
-      while (i >= 0 && !(lines[i].trim().includes(lastLine) || lastLine.includes(lines[i].trim()))) i--;
-      terminalContents = i === -1 ? lines.join("\n") : lines.slice(i).join("\n");
+      while (i >= 0) {
+        const strippedLine = stripNonASCIIAndSpaces(lines[i]);
+        if (strippedLine.startsWith(lastLine)) {
+          break;
+        }
+        i--;
+        terminalContents = i === -1 ? lines.join("\n") : lines.slice(i).join("\n");
+      }
     }
-
     return terminalContents;
   }
 


### PR DESCRIPTION
I added logging to see why only the SyntaxError: invalid syntax was being printed

`getTerminalContents called with commands: 1
extensionHostProcess.js:63105
Initial clipboard contents saved.
extensionHostProcess.js:63105
Selecting the last 1 commands from the terminal.
extensionHostProcess.js:63105
Copying selected text from terminal.
extensionHostProcess.js:63105
Terminal contents copied: nathanan@Nathans-MacBook-Air  ~/Documents/working-dir/pearai-app/extensions/pearai-submodule/extensions/vscode   main ±  cd ..
 nathanan@Nathans-MacBook-Air  ~/Documents/working-dir/pearai-app/extensions/pearai-submodule
 nathanan@Nathans-MacBook-Air  ~/Documents/working-dir/pearai-app/extensions/pearai-submodule   main ±  python3 extensions/vscode/pearai_tutorial.py
  File "/Users/nathanan/Documents/working-dir/pearai-app/extensions/pearai-submodule/extensions/vscode/pearai_tutorial.py", line 63
    print_list(["a", "b", "c"])``
                               ^
SyntaxError: invalid syntax
 ✘ nathanan@Nathans-MacBook-Air  ~/Documents/working-dir/pearai-app/extensions/pearai-submodule   main ± 
extensionHostProcess.js:63105
Restored clipboard contents.
extensionHostProcess.js:63105
Splitting terminal contents into lines: (8) ['nathanan@Nathans-MacBook-Air  ~/Documents/workin…i-submodule/extensions/vscode   main ±  cd ..', ' nathanan@Nathans-MacBook-Air  ~/Documents/working-dir/pearai-app/extensions/pearai-submodule', ' nathanan@Nathans-MacBook-Air  ~/Documents/worki…±  python3 extensions/vscode/pearai_tutorial.py', '  File "/Users/nathanan/Documents/working-dir/pea…e/extensions/vscode/pearai_tutorial.py", line 63', '    print_list(["a", "b", "c"])``', '                               ^', 'SyntaxError: invalid syntax', ' ✘ nathanan@Nathans-MacBook-Air  ~/Documents/wor…rai-app/extensions/pearai-submodule   main ± ']
extensionHostProcess.js:63105
Last line extracted: ✘ nathanan@Nathans-MacBook-Air  ~/Documents/working-dir/pearai-app/extensions/pearai-submodule   main ± 
extensionHostProcess.js:63105
Manually adjusted terminal contents: SyntaxError: invalid syntax`
 

So there's a bug in continue's code

there's 2 issues when running in PearAI:
1. sometimes theres special charaters, like an x indicating error at the start of a line
2. if i == -1, we take the last element of the array , which is unintended - what is intended is that we take the entire array if we get to i==-1

this commit fixes both. why does this work in continue? not sure :O but logically it doesnt work in pearai and it's being observed. this fixes it and now its observed to be working 🎆 
