### PR TITLE
Issue #127 | Config migration from .vscode to .pearai-dev

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,10 +1,12 @@
-/**
- * This is the entry point for the extension.
- */
-
 import { Telemetry } from "core/util/posthog";
 import * as vscode from "vscode";
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
 import { getExtensionVersion } from "./util/util";
+
+const pearAISettingsDir = path.join(os.homedir(), '.pearai');
+const firstLaunchFlag = path.join(pearAISettingsDir, 'firstLaunch.flag');
 
 async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
   const { activateExtension } = await import("./activation/activate");
@@ -29,7 +31,51 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
   }
 }
 
+function getVSCodeSettingsDir() {
+  const platform = process.platform;
+  if (platform === 'win32') {
+    return path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User');
+  } else if (platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'Code', 'User');
+  } else {
+    return path.join(os.homedir(), '.config', 'Code', 'User');
+  }
+}
+
+function promptUserToCopySettings() {
+  vscode.window.showInformationMessage('Do you want to copy your current VSCode settings to PearAI?', 'Yes', 'No')
+    .then(selection => {
+      if (selection === 'Yes') {
+        copyVSCodeSettingsToPearAI();
+      }
+      fs.writeFileSync(firstLaunchFlag, 'This is the first launch flag file');
+    });
+}
+
+function copyVSCodeSettingsToPearAI() {
+  const vscodeSettingsDir = getVSCodeSettingsDir();
+  const pearAIUserSettingsDir = path.join(pearAISettingsDir, 'User');
+
+  if (!fs.existsSync(pearAIUserSettingsDir)) {
+    fs.mkdirSync(pearAIUserSettingsDir, { recursive: true });
+  }
+
+  const filesToCopy = ['settings.json', 'keybindings.json', 'snippets'];
+  filesToCopy.forEach(file => {
+    const source = path.join(vscodeSettingsDir, file);
+    const destination = path.join(pearAIUserSettingsDir, file);
+    if (fs.existsSync(source)) {
+      fs.copyFileSync(source, destination);
+    }
+  });
+
+  vscode.window.showInformationMessage('Your VSCode settings have been copied to PearAI.');
+}
+
 export function activate(context: vscode.ExtensionContext) {
+  if (!fs.existsSync(firstLaunchFlag)) {
+    promptUserToCopySettings();
+  }
   dynamicImportAndActivate(context);
 }
 

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -48,10 +48,10 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
 }
 
 function copySettingsAndInformUser() {
-  vscode.window.showInformationMessage('Copying your current VSCode settings and extensions to the PearAI directories...');
+  vscode.window.showInformationMessage('Copying your current VSCode settings and extensions over to PearAI!');
   copyVSCodeSettingsToPearAIDir();
   fs.writeFileSync(firstLaunchFlag, 'This is the first launch flag file');
-  vscode.window.showInformationMessage('Your VSCode settings and extensions have been copied to the PearAI settings directory. You might need to restart your editor for the changes to take effect.', 'Ok');
+  vscode.window.showInformationMessage('Your VSCode settings and extensions have been transferred over to PearAI! You may need to restart your editor for the changes to take effect.', 'Ok');
 }
 
 function copyVSCodeSettingsToPearAIDir() {

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -5,12 +5,23 @@ import * as path from 'path';
 import * as os from 'os';
 import { getExtensionVersion } from "./util/util";
 
-const pearAISettingsDir = path.join(os.homedir(), '.pearai');
+const pearAISettingsDir = path.join(os.homedir(), '.pearai-dev');
 const firstLaunchFlag = path.join(pearAISettingsDir, 'firstLaunch.flag');
 
+function getPearAIDevSettingsDir() {
+  const platform = process.platform;
+  if (platform === 'win32') {
+    return path.join(process.env.APPDATA || '', 'pearai-dev', 'User');
+  } else if (platform === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Application Support', 'pearai-dev', 'User');
+  } else {
+    return path.join(os.homedir(), '.config', 'pearai-dev', 'User');
+  }
+}
+
 async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
-  const { activateExtension } = await import("./activation/activate");
   try {
+    const { activateExtension } = await import("./activation/activate");
     await activateExtension(context);
   } catch (e) {
     console.log("Error activating extension: ", e);
@@ -31,10 +42,43 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
   }
 }
 
+function promptUserToCopySettings() {
+  vscode.window.showInformationMessage('Do you want to copy your current VSCode settings to the PearAI settings directory?', 'Yes', 'No')
+    .then(selection => {
+      if (selection === 'Yes') {
+        copyVSCodeSettingsToPearAIDir();
+      }
+      fs.writeFileSync(firstLaunchFlag, 'This is the first launch flag file');
+    });
+}
+
+function copyVSCodeSettingsToPearAIDir() {
+  const vscodeSettingsDir = getVSCodeSettingsDir();
+  const pearAIDevSettingsDir = getPearAIDevSettingsDir();
+
+  if (!fs.existsSync(pearAIDevSettingsDir)) {
+    fs.mkdirSync(pearAIDevSettingsDir, { recursive: true });
+  }
+
+  const itemsToCopy = ['settings.json', 'keybindings.json', 'snippets', 'sync'];
+  itemsToCopy.forEach(item => {
+    const source = path.join(vscodeSettingsDir, item);
+    const destination = path.join(pearAIDevSettingsDir, item);
+    if (fs.existsSync(source)) {
+      if (fs.lstatSync(source).isDirectory()) {
+        copyDirectoryRecursiveSync(source, destination);
+      } else {
+        fs.copyFileSync(source, destination);
+      }
+    }
+  });
+  vscode.window.showInformationMessage('Your VSCode settings have been copied to the PearAI settings directory.');
+}
+
 function getVSCodeSettingsDir() {
   const platform = process.platform;
   if (platform === 'win32') {
-    return path.join(os.homedir(), 'AppData', 'Roaming', 'Code', 'User');
+    return path.join(process.env.APPDATA || '', 'Code', 'User');
   } else if (platform === 'darwin') {
     return path.join(os.homedir(), 'Library', 'Application Support', 'Code', 'User');
   } else {
@@ -42,34 +86,19 @@ function getVSCodeSettingsDir() {
   }
 }
 
-function promptUserToCopySettings() {
-  vscode.window.showInformationMessage('Do you want to copy your current VSCode settings to PearAI?', 'Yes', 'No')
-    .then(selection => {
-      if (selection === 'Yes') {
-        copyVSCodeSettingsToPearAI();
-      }
-      fs.writeFileSync(firstLaunchFlag, 'This is the first launch flag file');
-    });
-}
-
-function copyVSCodeSettingsToPearAI() {
-  const vscodeSettingsDir = getVSCodeSettingsDir();
-  const pearAIUserSettingsDir = path.join(pearAISettingsDir, 'User');
-
-  if (!fs.existsSync(pearAIUserSettingsDir)) {
-    fs.mkdirSync(pearAIUserSettingsDir, { recursive: true });
+function copyDirectoryRecursiveSync(source: string, destination: string) {
+  if (!fs.existsSync(destination)) {
+    fs.mkdirSync(destination, { recursive: true });
   }
-
-  const filesToCopy = ['settings.json', 'keybindings.json', 'snippets'];
-  filesToCopy.forEach(file => {
-    const source = path.join(vscodeSettingsDir, file);
-    const destination = path.join(pearAIUserSettingsDir, file);
-    if (fs.existsSync(source)) {
-      fs.copyFileSync(source, destination);
+  fs.readdirSync(source).forEach(item => {
+    const sourcePath = path.join(source, item);
+    const destinationPath = path.join(destination, item);
+    if (fs.lstatSync(sourcePath).isDirectory()) {
+      copyDirectoryRecursiveSync(sourcePath, destinationPath);
+    } else {
+      fs.copyFileSync(sourcePath, destinationPath);
     }
   });
-
-  vscode.window.showInformationMessage('Your VSCode settings have been copied to PearAI.');
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -83,6 +112,5 @@ export function deactivate() {
   Telemetry.capture("deactivate", {
     extensionVersion: getExtensionVersion(),
   });
-
   Telemetry.shutdownPosthogClient();
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -47,14 +47,11 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
   }
 }
 
-function promptUserToCopySettings() {
-  vscode.window.showInformationMessage('Do you want to copy your current VSCode settings and extensions to the PearAI directories?', 'Yes', 'No')
-    .then(selection => {
-      if (selection === 'Yes') {
-        copyVSCodeSettingsToPearAIDir();
-      }
-      fs.writeFileSync(firstLaunchFlag, 'This is the first launch flag file');
-    });
+function copySettingsAndInformUser() {
+  vscode.window.showInformationMessage('Copying your current VSCode settings and extensions to the PearAI directories...');
+  copyVSCodeSettingsToPearAIDir();
+  fs.writeFileSync(firstLaunchFlag, 'This is the first launch flag file');
+  vscode.window.showInformationMessage('Your VSCode settings and extensions have been copied to the PearAI settings directory. You might need to restart your editor for the changes to take effect.', 'Ok');
 }
 
 function copyVSCodeSettingsToPearAIDir() {
@@ -84,8 +81,6 @@ function copyVSCodeSettingsToPearAIDir() {
   });
 
   copyDirectoryRecursiveSync(vscodeExtensionsDir, pearAIDevExtensionsDir);
-
-  vscode.window.showInformationMessage('Your VSCode settings and extensions have been copied to the PearAI settings directory. You might need to restart your editor for the changes to take effect.', 'Ok');
 }
 
 function getVSCodeSettingsDir() {
@@ -116,7 +111,7 @@ function copyDirectoryRecursiveSync(source: string, destination: string) {
 
 export function activate(context: vscode.ExtensionContext) {
   if (!fs.existsSync(firstLaunchFlag)) {
-    promptUserToCopySettings();
+    copySettingsAndInformUser();
   }
   dynamicImportAndActivate(context);
 }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -7,6 +7,7 @@ import { getExtensionVersion } from "./util/util";
 
 const pearAISettingsDir = path.join(os.homedir(), '.pearai-dev');
 const firstLaunchFlag = path.join(pearAISettingsDir, 'firstLaunch.flag');
+const pearAIDevExtensionsDir = path.join(os.homedir(), '.pearai-dev', 'extensions');
 
 function getPearAIDevSettingsDir() {
   const platform = process.platform;
@@ -17,6 +18,10 @@ function getPearAIDevSettingsDir() {
   } else {
     return path.join(os.homedir(), '.config', 'pearai-dev', 'User');
   }
+}
+
+function getVSCodeExtensionsDir() {
+  return path.join(os.homedir(), '.vscode', 'extensions');
 }
 
 async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
@@ -43,7 +48,7 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
 }
 
 function promptUserToCopySettings() {
-  vscode.window.showInformationMessage('Do you want to copy your current VSCode settings to the PearAI settings directory?', 'Yes', 'No')
+  vscode.window.showInformationMessage('Do you want to copy your current VSCode settings and extensions to the PearAI directories?', 'Yes', 'No')
     .then(selection => {
       if (selection === 'Yes') {
         copyVSCodeSettingsToPearAIDir();
@@ -55,9 +60,14 @@ function promptUserToCopySettings() {
 function copyVSCodeSettingsToPearAIDir() {
   const vscodeSettingsDir = getVSCodeSettingsDir();
   const pearAIDevSettingsDir = getPearAIDevSettingsDir();
+  const vscodeExtensionsDir = getVSCodeExtensionsDir();
 
   if (!fs.existsSync(pearAIDevSettingsDir)) {
     fs.mkdirSync(pearAIDevSettingsDir, { recursive: true });
+  }
+
+  if (!fs.existsSync(pearAIDevExtensionsDir)) {
+    fs.mkdirSync(pearAIDevExtensionsDir, { recursive: true });
   }
 
   const itemsToCopy = ['settings.json', 'keybindings.json', 'snippets', 'sync'];
@@ -72,7 +82,10 @@ function copyVSCodeSettingsToPearAIDir() {
       }
     }
   });
-  vscode.window.showInformationMessage('Your VSCode settings have been copied to the PearAI settings directory.');
+
+  copyDirectoryRecursiveSync(vscodeExtensionsDir, pearAIDevExtensionsDir);
+
+  vscode.window.showInformationMessage('Your VSCode settings and extensions have been copied to the PearAI settings directory. You might need to restart your editor for the changes to take effect.', 'Ok');
 }
 
 function getVSCodeSettingsDir() {


### PR DESCRIPTION
## Description

On first run, copies all settings (including extensions and themes) and sync settings from .vscode to .pearai-dev for seamless ide transition although some settings might not apply automatically, will require restart