### PR TITLE
Check if source dir exists before migration of extensions

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -95,6 +95,9 @@ function getVSCodeSettingsDir() {
 }
 
 function copyDirectoryRecursiveSync(source: string, destination: string) {
+  if (!fs.existsSync(source)) {
+    return;
+  }
   if (!fs.existsSync(destination)) {
     fs.mkdirSync(destination, { recursive: true });
   }


### PR DESCRIPTION
Sorry for the sudden PR and not creating an Issue. I want to fix this quickly as it is blocking my development.

## Description

### What

- Follow-up: https://github.com/trypear/pearai-submodule/pull/52

Check if `source` directory exists before migration of extensions (copying `.vscode/extensions`)

### Why

This avoids a crash on migration for users who don't have VS Code installed, and for developers (somehow my `pearai-app` build on Docker does not create the `~/.vscode` dir but the `~/.vscode-oss-dev` dir, which probably causes the same error).

| Before | After |
| --- | --- |
| <img src="https://github.com/trypear/pearai-submodule/assets/34566290/4a2422a0-32b2-45f3-b26e-9fdf259896a8" > | <img src="https://github.com/trypear/pearai-submodule/assets/34566290/e031692d-f9df-4fbc-8e0e-7bc926e2c14d"> |


## Checklist

- [ ] The base branch of this PR is `preview`, rather than `main`

So, where is `preview` ?
