### PR TITLE
Replace `height` css with `min-height` to prevent content from sticking over down

### DIFF
--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -35,7 +35,7 @@ import ModelSelect from "./modelSelection/ModelSelect";
 const FOOTER_HEIGHT = "1.8em";
 
 const LayoutTopDiv = styled(CustomScrollbarDiv)`
-  height: 100%;
+  min-height: 100%;
   border-radius: ${defaultBorderRadius};
 `;
 
@@ -74,7 +74,7 @@ const Footer = styled.footer`
 const GridDiv = styled.div`
   display: grid;
   grid-template-rows: 1fr auto;
-  height: 100vh;
+  min-height: 100vh;
   overflow-x: visible;
 `;
 

--- a/gui/src/index.css
+++ b/gui/src/index.css
@@ -17,7 +17,7 @@
 html,
 body,
 #root {
-  height: 100%;
+  min-height: 100%;
   background-color: var(--vscode-editor-background);
   font-family:
     system-ui,
@@ -38,7 +38,7 @@ body {
   color: var(--vscode-editor-foreground);
   padding: 0px;
   margin: 0px;
-  height: 100%;
+  min-height: 100%;
 }
 
 a:focus {


### PR DESCRIPTION
## Description

Just nits issue.

### What

If the pane is too narrow, the content on e.g. Onboarding page sticks over down from the container because the container's height is fixed.

Just replace `height` with `min-height` and it should fix this.

| Before | After |
| --- | --- |
|  <img src="https://github.com/trypear/pearai-submodule/assets/34566290/0b279b1a-23cc-49f0-85a5-ee50ca5250fd" > | <img src="https://github.com/trypear/pearai-submodule/assets/34566290/34926ba0-3286-4768-92ab-5ef3d9f5e5e0" > |

I didn't check the other pages, but we should probably do that before we merge.
