### PR TITLE
Open extension panel during first onboarding

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -25,6 +25,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
         path.join(getExtensionUri().fsPath, "media", "welcome.md"),
       ),
     );
+    vscode.commands.executeCommand("continue.continueGUIView.focus");
   });
 
   // Load PearAI configuration

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -25,7 +25,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
         path.join(getExtensionUri().fsPath, "media", "welcome.md"),
       ),
     );
-    vscode.commands.executeCommand("continue.continueGUIView.focus");
+    vscode.commands.executeCommand("pearai.continueGUIView.focus");
   });
 
   // Load PearAI configuration


### PR DESCRIPTION
## Description

### What

- fixes: https://github.com/trypear/pearai-app/issues/131

Once the extension is activated, we'll open the pane up so users can jump right into the onboarding and the tutorial.

If we can skip the model selection process (or wait until after the tutorial is done), we can immediately open the tutorial file as well.

### Video


https://github.com/trypear/pearai-submodule/assets/34566290/47863d4d-39fe-4393-b06a-dd640bffcc5c


