### PR TITLE
Changed help center links and shortcuts

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pearai",
-  "version": "0.9.157",
+  "version": "0.9.159",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pearai",
-      "version": "0.9.157",
+      "version": "0.9.159",
       "license": "Apache-2.0",
       "dependencies": {
         "@electron/rebuild": "^3.2.10",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pearai",
   "icon": "media/icon.png",
-  "version": "0.9.157",
+  "version": "0.9.159",
   "repository": {
     "type": "git",
     "url": "https://github.com/trypear/pearai-app"

--- a/gui/src/components/dialogs/KeyboardShortcuts.tsx
+++ b/gui/src/components/dialogs/KeyboardShortcuts.tsx
@@ -95,6 +95,16 @@ const vscodeShortcuts: KeyboardShortcutProps[] = [
     description: "Select Code + New Session",
   },
   {
+    mac: "⌘ [",
+    windows: "⌃ [",
+    description: "Enlarge Pear chat",
+  },
+  {
+    mac: "⌘ :",
+    windows: "⌃ :",
+    description: "Close Pear chat",
+  },
+  {
     mac: "⌘ I",
     windows: "⌃ I",
     description: "Edit highlighted code",

--- a/gui/src/pages/help.tsx
+++ b/gui/src/pages/help.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftIcon } from "@heroicons/react/24/outline";
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import {
@@ -128,7 +128,7 @@ function HelpPage() {
           </a>
         </IconDiv>
         <IconDiv backgroundColor="rgb(88, 98, 227)">
-          <a href="https://discord.gg/vapESyrFmJ" target="_blank">
+          <a href="https://discord.gg/Uw9mVvFUk3" target="_blank">
             <svg
               width="42px"
               height="42px"


### PR DESCRIPTION
## Description
Help center had the default links and we needed to update them.

## Checklist

- [X] Discord -> PearAI Discord
- [X] Github Issues (this was done already with the link: https://github.com/trypear/pearai-app/issues/new/choose) -> change link to https://github.com/trypear/pearai-app/issues 
- [X] Keyboard shortcuts: add CMD+[ with "Enlarge Pear chat" and CMD+: for "Close Pear chat"
- [X] Documentation and demo video can be kept same for now until we make one ourselves

