### PR TITLE
Made prettier use single-quote on both normal and jsx strings.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,7 @@
 {
   "tabWidth": 2,
   "useTabs": false,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "singleQuote": true,
+  "jsxSingleQuote": true
 }


### PR DESCRIPTION
## Description

Made prettier use single-quote on both normal and jsx strings to avoid generating eslint warnings.
Issue link: https://github.com/trypear/pearai-app/issues/150

## Checklist

- [X] Edit .prettierrc to use single quote strings.
