### PR TITLE
feat: set default location PearAI extension to auxiliary bar

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -19,6 +19,9 @@ export async function activateExtension(context: vscode.ExtensionContext) {
   const vscodeExtension = new VsCodeExtension(context);
 
   migrate("showWelcome_1", () => {
+    // move pearai extension to auxiliary bar (we want secondary side bar to be default loaction for extension)
+    vscode.commands.executeCommand('workbench.action.moveSpecificExtensionToAuxBar');
+
     vscode.commands.executeCommand(
       "markdown.showPreview",
       vscode.Uri.file(

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -20,7 +20,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
   migrate("showWelcome_1", () => {
     // move pearai extension to auxiliary bar (we want secondary side bar to be default loaction for extension)
-    vscode.commands.executeCommand('workbench.action.moveSpecificExtensionToAuxBar');
+    vscode.commands.executeCommand('workbench.action.movePearExtensionToAuxBar');
 
     vscode.commands.executeCommand(
       "markdown.showPreview",


### PR DESCRIPTION
 #trypear/pearai-app#22
what this change does :
- when extension activates the very first time, move PearAI extension to auxiliary bar
