### PR TITLE
feat: add big chat shortcut to view/title

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -215,6 +215,18 @@
         "group": "PearAI"
       },
       {
+        "command": "pearai.macResizeAuxiliaryBarWidth",
+        "category": "PearAI",
+        "title": "Big Chat (CMD + [)",
+        "group": "PearAI"
+      },
+      {
+        "command": "pearai.winResizeAuxiliaryBarWidth",
+        "category": "PearAI",
+        "title": "Big Chat (ALT + [)",
+        "group": "PearAI"
+      },
+      {
         "command": "pearai.writeDocstringForCode",
         "category": "PearAI",
         "title": "Write a Docstring for this Code",
@@ -385,6 +397,16 @@
         }
       ],
       "view/title": [
+        {
+          "command": "pearai.winResizeAuxiliaryBarWidth",
+          "group": "navigation@0",
+          "when": "view == pearai.continueGUIView && (isWindows || isLinux)"
+        },
+        {
+          "command": "pearai.macResizeAuxiliaryBarWidth",
+          "group": "navigation@0",
+          "when": "view == pearai.continueGUIView && isMac"
+        },
         {
           "command": "pearai.newSession",
           "group": "navigation@1",

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -475,6 +475,15 @@ const commandsMap: (
     "pearai.viewHistory": () => {
       sidebar.webviewProtocol?.request("viewHistory", undefined);
     },
+    "pearai.resizeAuxiliaryBarWidth": () => {
+      vscode.commands.executeCommand("workbench.action.resizeAuxiliaryBarWidth");
+    },
+    "pearai.winResizeAuxiliaryBarWidth": () => {
+      vscode.commands.executeCommand("pearai.resizeAuxiliaryBarWidth");
+    },
+    "pearai.macResizeAuxiliaryBarWidth": () => {
+      vscode.commands.executeCommand("pearai.resizeAuxiliaryBarWidth");
+    },
     "pearai.toggleFullScreen": () => {
       // Check if full screen is already open by checking open tabs
       const fullScreenTab = getFullScreenTab();


### PR DESCRIPTION
 What changed -
- add shortcut display to pearai extension toolbar view.
- it will display CMD L on mac and ALT L on windows and linux (as linux users mostly would using a windows keyboard layout)

- the shortcut is hardcoded in title string, it will remain static for now until we figure out a way to change it.

![image](https://github.com/trypear/pearai-submodule/assets/26621232/d66327d7-d06c-486d-8837-54b02fc8ddb9)
