### PR TITLE
name change for PearAI server model panel

### DIFF
--- a/gui/src/pages/modelconfig.tsx
+++ b/gui/src/pages/modelconfig.tsx
@@ -194,7 +194,7 @@ function ModelConfig() {
                   <ModelCard
                     key={idx}
                     disabled={disableModelCards()}
-                    title={"Add PearAI Server"}
+                    title={"Start Coding 😎"}     
                     description={""}
                     tags={pkg.tags}
                     dimensions={pkg.dimensions}


### PR DESCRIPTION
- Changed "Add PearAI Server" button to "Start Coding 😎" for the server model panel. 

- Still working on the other asked for changes but wanted to send the PR for this first change.

---
Before:
![image](https://github.com/trypear/pearai-submodule/assets/132936435/e7a2c377-5e28-4950-ab5b-7ddc9a8f2341)


After:
![CleanShot 2024-07-05 at 12 43 09@2x](https://github.com/trypear/pearai-submodule/assets/132936435/e9a3b5bf-354b-43be-b204-2207c027cd07)

Maintainer edited: related to: https://github.com/trypear/pearai-app/issues/157
