### PR TITLE
view history shortcut

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -215,15 +215,21 @@
         "group": "PearAI"
       },
       {
+        "command": "pearai.resizeAuxiliaryBarWidth",
+        "category": "PearAI",
+        "title": "Resize Chat",
+        "group": "PearAI"
+      },
+      {
         "command": "pearai.macResizeAuxiliaryBarWidth",
         "category": "PearAI",
-        "title": "Big Chat (CMD + [)",
+        "title": "Big Chat - CMD + [",
         "group": "PearAI"
       },
       {
         "command": "pearai.winResizeAuxiliaryBarWidth",
         "category": "PearAI",
-        "title": "Big Chat (ALT + [)",
+        "title": "Big Chat - CTRL + [",
         "group": "PearAI"
       },
       {
@@ -261,6 +267,11 @@
         "command": "pearai.focusContinueInputWithoutClear",
         "mac": "cmd+shift+l",
         "key": "ctrl+shift+l"
+      },
+      {
+        "command": "pearai.resizeAuxiliaryBarWidth",
+        "mac": "cmd+[",
+        "key": "ctrl+["
       },
       {
         "command": "pearai.acceptDiff",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -274,6 +274,11 @@
         "key": "ctrl+["
       },
       {
+        "command": "pearai.viewHistory",
+        "mac": "cmd+o",
+        "key": "ctrl+o"
+      },
+      {
         "command": "pearai.acceptDiff",
         "mac": "shift+cmd+enter",
         "key": "shift+ctrl+enter"


### PR DESCRIPTION
- added shortcut for view history - `cmd + o` and `ctrl + o`
- change alt to ctrl for resize chat.
- remove parenthesis from shortcut display of big chat.


rest all shortcuts are good for windows. they are set to ctrl.
