### PR TITLE
Fix more styles for config pages

### DIFF
--- a/gui/src/components/dialogs/KeyboardShortcuts.tsx
+++ b/gui/src/components/dialogs/KeyboardShortcuts.tsx
@@ -10,7 +10,7 @@ import { getPlatform } from "../../util";
 
 const GridDiv = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: 1fr;
   grid-gap: 2rem;
   padding: 1rem;
   justify-items: center;
@@ -71,15 +71,15 @@ interface KeyboardShortcutProps {
 function KeyboardShortcut(props: KeyboardShortcutProps) {
   const shortcut = getPlatform() === "mac" ? props.mac : props.windows;
   return (
-    <div className="flex justify-between w-full items-center">
-      <span
+    <div className='flex justify-between w-full items-center gap-3'>
+      <div
         style={{
           color: vscForeground,
         }}
       >
         {props.description}
-      </span>
-      <div className="flex gap-2 float-right">
+      </div>
+      <div className='flex gap-2'>
         {shortcut.split(" ").map((key, i) => {
           return <KeyDiv key={i} text={key}></KeyDiv>;
         })}
@@ -218,7 +218,7 @@ function KeyboardShortcutsDialog() {
   return (
     <div className="p-2">
       <h3 className="my-3 mx-auto text-center">Keyboard Shortcuts</h3>
-      <GridDiv>
+      <GridDiv className='overflow-x-auto'>
         {(localStorage.getItem("ide") === "jetbrains"
           ? jetbrainsShortcuts
           : vscodeShortcuts

--- a/gui/src/pages/models.tsx
+++ b/gui/src/pages/models.tsx
@@ -22,7 +22,7 @@ const IntroDiv = styled.div`
 
 const GridDiv = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: 1fr;
   grid-gap: 2rem;
   padding: 1rem;
   justify-items: center;
@@ -37,7 +37,7 @@ function Models() {
   const [providersSelected, setProvidersSelected] = React.useState(true);
 
   return (
-    <div className="overflow-y-scroll">
+    <div>
       <div
         className="items-center flex m-0 p-0 sticky top-0"
         style={{


### PR DESCRIPTION
## Description

- Related: https://github.com/trypear/pearai-app/issues/157
- Follow-up: https://github.com/trypear/pearai-submodule/pull/83, https://github.com/trypear/pearai-submodule/pull/86#discussion_r1667669662

Fix some grid style, though I have no idea why `grid` is used here... (we can just use `flex` more simpily)

## Screenshots

### Models page
| Before | After |
| --- | --- |
| **content overflown, and unnecessary y scroll bar** <br/><br/> ![image](https://github.com/trypear/pearai-submodule/assets/34566290/485beb1a-3d51-42f6-86e6-74a4027bb859) | ![image](https://github.com/trypear/pearai-submodule/assets/34566290/454bcbbb-5da9-4c99-a714-ad3d8ea64947) |





### Keyboard shortcuts page

| Before | After |
| --- | --- |
| **content overflown, and unnecessary y scroll bar** <br/><br/> ![image](https://github.com/trypear/pearai-submodule/assets/34566290/afa4584d-9d7b-4903-b62c-1105250a8ee8) | ![image](https://github.com/trypear/pearai-submodule/assets/34566290/ed5bea7e-26ae-45ba-8cac-68dc95e9e0c6) |




## Checklist

- [ ] The base branch of this PR is `preview`, rather than `main`
