### PR TITLE
open session at bottom

### DIFF
--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -205,12 +205,15 @@ function GUI(props: GUIProps) {
     };
 
     window.addEventListener("scroll", handleScroll);
-    window.scrollTo({
-      top: topGuiDivRef.current?.scrollHeight,
-      behavior: "instant" as any,
-    });
+    const timeoutId = setTimeout(() => {
+      window.scrollTo({
+        top: topGuiDivRef.current?.scrollHeight,
+        behavior: "instant" as any,
+      });
+    }, 1);
 
     return () => {
+      clearTimeout(timeoutId)
       window.removeEventListener("scroll", handleScroll);
     };
   }, [topGuiDivRef.current]);

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -218,15 +218,6 @@ function GUI(props: GUIProps) {
     };
   }, [topGuiDivRef.current]);
 
-  useLayoutEffect(() => {
-    if (userScrolledAwayFromBottom) return;
-
-    window.scrollTo({
-      top: topGuiDivRef.current?.scrollHeight,
-      behavior: "instant" as any,
-    });
-  }, [topGuiDivRef.current?.scrollHeight, sessionState.history]);
-
   useEffect(() => {
     // Cmd + Backspace to delete current step
     const listener = (e: any) => {

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -193,7 +193,7 @@ function GUI(props: GUIProps) {
     const handleScroll = () => {
       // Scroll only if user is within 200 pixels of the bottom of the window.
       const edgeOffset = -25;
-      const scrollPosition = topGuiDivRef.current?.scrollTop || 0;
+      const scrollPosition = Math.max(window.pageYOffset, document.documentElement.scrollTop, document.body.scrollTop) || 0;
       const scrollHeight = topGuiDivRef.current?.scrollHeight || 0;
       const clientHeight = window.innerHeight || 0;
 
@@ -204,7 +204,11 @@ function GUI(props: GUIProps) {
       }
     };
 
-    topGuiDivRef.current?.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll);
+    window.scrollTo({
+      top: topGuiDivRef.current?.scrollHeight,
+      behavior: "instant" as any,
+    });
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
@@ -214,7 +218,7 @@ function GUI(props: GUIProps) {
   useLayoutEffect(() => {
     if (userScrolledAwayFromBottom) return;
 
-    topGuiDivRef.current?.scrollTo({
+    window.scrollTo({
       top: topGuiDivRef.current?.scrollHeight,
       behavior: "instant" as any,
     });


### PR DESCRIPTION
current behaviour - opening any session loads at the top, even when switching between them.
this pr fixes that, sessions loads and scrolls to the bottom. 

used setTimeout with with delay 1ms to perform scrolling after 1st render cycle, for some reason 2-3 renders are happening whenever a session is loaded. this way scroll happens a little less janky.

