### PR TITLE
Added error handle for 401 Error, allow redirect to login auth url

### DIFF
--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -139,7 +139,7 @@ export class VsCodeWebviewProtocol {
                   // Redirect to auth login URL
                   vscode.env.openExternal(
                     vscode.Uri.parse(
-                      'https://trypear.ai/signin?...llback=pearai://pearai.pearai/auth',
+                      'https://trypear.ai/signin?callback=pearai://pearai.pearai/auth',
                     ),
                   );
                 }

--- a/extensions/vscode/src/webviewProtocol.ts
+++ b/extensions/vscode/src/webviewProtocol.ts
@@ -118,7 +118,33 @@ export class VsCodeWebviewProtocol {
           );
 
           let message = e.message;
-          if (e.cause) {
+          if (e.status === 401) {
+            vscode.window
+              .showErrorMessage(
+                message,
+                'Show Logs',
+                'Troubleshooting',
+                'Re-login',
+              )
+              .then((selection) => {
+                if (selection === 'Show Logs') {
+                  vscode.commands.executeCommand(
+                    'workbench.action.toggleDevTools',
+                  );
+                } else if (selection === 'Troubleshooting') {
+                  vscode.env.openExternal(
+                    vscode.Uri.parse('https://trypear.ai/troubleshooting'),
+                  );
+                } else if (selection === 'Re-login') {
+                  // Redirect to auth login URL
+                  vscode.env.openExternal(
+                    vscode.Uri.parse(
+                      'https://trypear.ai/signin?...llback=pearai://pearai.pearai/auth',
+                    ),
+                  );
+                }
+              });
+          } else if (e.cause) {
             if (e.cause.name === "ConnectTimeoutError") {
               message = `Connection timed out. If you expect it to take a long time to connect, you can increase the timeout in config.json by setting "requestOptions": { "timeout": 10000 }. You can find the full config reference here: https://trypear.ai/reference/config`;
             } else if (e.cause.code === "ECONNREFUSED") {


### PR DESCRIPTION
## Description

As the title, however, I currently haven't found a method to reproduce the error. As a result, we might have to merge and then test in prod.


## Add

Add a third option when the user faces the 401 Error, allow redirect to login #195 issue in pearai-app
