### PR TITLE
fix file context provider stale

### DIFF
--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -231,6 +231,23 @@ export class VsCodeExtension {
       this.tabAutocompleteModel.clearLlm();
     });
 
+
+    // Create a file system watcher
+    const watcher = vscode.workspace.createFileSystemWatcher('**/*', false, false, false);
+
+    // Handle file creation
+    watcher.onDidCreate(uri => {
+      this.refreshContextProviders();
+    });
+  
+    // Handle file deletion
+    watcher.onDidDelete(uri => {
+      console.log(`File deleted: ${uri}`);
+      this.refreshContextProviders();
+    });
+  
+    context.subscriptions.push(watcher);
+
     vscode.workspace.onDidSaveTextDocument((event) => {
       // Listen for file changes in the workspace
       const filepath = event.uri.fsPath;
@@ -299,6 +316,10 @@ export class VsCodeExtension {
   private PREVIOUS_BRANCH_FOR_WORKSPACE_DIR: { [dir: string]: string } = {};
   private indexingCancellationController: AbortController | undefined;
 
+  private async refreshContextProviders() {
+    this.webviewProtocol.request("refreshSubmenuItems", undefined); // Refresh all context providers
+  }
+
   private async refreshCodebaseIndex(
     dirs: string[],
     context: vscode.ExtensionContext,
@@ -322,6 +343,8 @@ export class VsCodeExtension {
       this.webviewProtocol.request("indexProgress", update);
       context.globalState.update("pearai.indexingProgress", update);
     }
+
+    this.refreshContextProviders();
 
     if (err) {
       console.log("Codebase Indexing Failed: ", err);

--- a/extensions/vscode/src/extension/vscodeExtension.ts
+++ b/extensions/vscode/src/extension/vscodeExtension.ts
@@ -242,7 +242,6 @@ export class VsCodeExtension {
   
     // Handle file deletion
     watcher.onDidDelete(uri => {
-      console.log(`File deleted: ${uri}`);
       this.refreshContextProviders();
     });
   


### PR DESCRIPTION
problem : @ file tagging (context provider) is not picking filefolder changes

this pr fixes it using filewatcher. any filefolder change is immediately picked and context providers are refreshed.

---

### dev notes:
- indexing got nothing to with context providers, both are separate.
- could also have done like this, but these events only happen if filefolder changes are done inside the vscode, it does not pick up the changes on the disk made by other applications.
```
 vscode.workspace.onDidCreateFiles((event) => {
   this.refreshContextProviders();
 });
 vscode.workspace.onDidDeleteFiles((event) => {
   this.refreshContextProviders();
 });
 vscode.workspace.onDidRenameFiles((event) => {
   this.refreshContextProviders();
 });
```

- renaming a file means deleting and creating, so renaming fires both events in file watcher (the implemented solution in this pr, not the above example, it has separate rename event `onDidRenameFiles`). 
