### PR TITLE
Draft: fix: Issue 262 Add custom context to give pearAi commands priority

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -297,27 +297,32 @@
       {
         "command": "pearai.focusContinueInput",
         "mac": "cmd+l",
-        "key": "ctrl+l"
+        "key": "ctrl+l",
+        "when": "editorTextFocus && pearai.active"
       },
       {
         "command": "pearai.focusContinueInputWithoutClear",
         "mac": "cmd+shift+l",
-        "key": "ctrl+shift+l"
+        "key": "ctrl+shift+l",
+        "when": "editorTextFocus && pearai.active"
       },
       {
         "command": "pearai.toggleAuxiliaryBar",
         "mac": "alt+cmd+l",
-        "key": "alt+ctrl+l"
+        "key": "alt+ctrl+l",
+        "when": "pearai.active"
       },
       {
         "command": "pearai.acceptDiff",
         "mac": "shift+cmd+enter",
-        "key": "shift+ctrl+enter"
+        "key": "shift+ctrl+enter",
+        "when": "pearai.active"
       },
       {
         "command": "pearai.rejectDiff",
         "mac": "shift+cmd+backspace",
-        "key": "shift+ctrl+backspace"
+        "key": "shift+ctrl+backspace",
+        "when": "pearai.active"
       },
       {
         "command": "pearai.rejectDiff",

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -36,6 +36,8 @@ async function dynamicImportAndActivate(context: vscode.ExtensionContext) {
 export function activate(context: vscode.ExtensionContext) {
   setupCa();
   setupSettingsAndInformUser();
+  // Fix Issue #262: Give priority to PearAI commands via context
+  vscode.commands.executeCommand('setContext', 'pearai.active', true);
   return dynamicImportAndActivate(context);
 }
 


### PR DESCRIPTION
## Description ✏️

Closes #262

What changed? Feel free to be brief.
adds Pearai custom context during extension activation to prioritize pearai commands

## Checklist ✅

- [x] The base branch of this PR is `preview`, rather than `main`
- [x] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).
