### PR TITLE
feat: #271 add default gpt4o and claude models

### DIFF
--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -95,9 +95,26 @@ export const defaultConfig: SerializedContinueConfig = {
     {
       "model": "pearai_model",
       "contextLength": 200000,
-      "title": "PearAI Server",
+      "title": "PearAI Server (Recommended)",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
-      "provider": "pearai_server"
+      "provider": "pearai_server",
+      "isDefault": true
+    },
+    {
+      "model": "claude_sonnet",
+      "contextLength": 200000,
+      "title": "Claude 3.5 Sonnet",
+      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
+      "provider": "anthropic",
+      "isDefault": true
+    },
+    {
+      "model": "chat_gpt4o",
+      "contextLength": 200000,
+      "title": "GPT4o",
+      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
+      "provider": "openai",
+      "isDefault": true
     }
   ],
   customCommands: [
@@ -116,6 +133,17 @@ export const defaultConfig: SerializedContinueConfig = {
   contextProviders: defaultContextProvidersVsCode,
   slashCommands: defaultSlashCommandsVscode,
 };
+function getConfigJsonPath(ideType: IdeType = "vscode"): string {
+  const p = path.join(getContinueGlobalPath(), "config.json");
+  if (!fs.existsSync(p)) {
+    if (ideType === "jetbrains") {
+      fs.writeFileSync(p, JSON.stringify(defaultConfigJetBrains, null, 2));
+    } else {
+      fs.writeFileSync(p, JSON.stringify(defaultConfig, null, 2));
+    }
+  }
+  return p;
+}
 
 export const defaultConfigJetBrains: SerializedContinueConfig = {
   models: FREE_TRIAL_MODELS,

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -101,7 +101,7 @@ export const defaultConfig: SerializedContinueConfig = {
       "isDefault": true
     },
     {
-      "model": "claude_sonnet",
+      "model": "claude-3-5-sonnet-20240620",
       "contextLength": 200000,
       "title": "Claude 3.5 Sonnet",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
@@ -109,9 +109,9 @@ export const defaultConfig: SerializedContinueConfig = {
       "isDefault": true
     },
     {
-      "model": "gpt4o",
+      "model": "gpt-4o",
       "contextLength": 200000,
-      "title": "GPT4o",
+      "title": "GPT-4o",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
       "provider": "openai",
       "isDefault": true

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -109,7 +109,7 @@ export const defaultConfig: SerializedContinueConfig = {
       "isDefault": true
     },
     {
-      "model": "chat_gpt4o",
+      "model": "gpt4o",
       "contextLength": 200000,
       "title": "GPT4o",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
@@ -133,17 +133,6 @@ export const defaultConfig: SerializedContinueConfig = {
   contextProviders: defaultContextProvidersVsCode,
   slashCommands: defaultSlashCommandsVscode,
 };
-function getConfigJsonPath(ideType: IdeType = "vscode"): string {
-  const p = path.join(getContinueGlobalPath(), "config.json");
-  if (!fs.existsSync(p)) {
-    if (ideType === "jetbrains") {
-      fs.writeFileSync(p, JSON.stringify(defaultConfigJetBrains, null, 2));
-    } else {
-      fs.writeFileSync(p, JSON.stringify(defaultConfig, null, 2));
-    }
-  }
-  return p;
-}
 
 export const defaultConfigJetBrains: SerializedContinueConfig = {
   models: FREE_TRIAL_MODELS,

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -94,28 +94,28 @@ export const defaultConfig: SerializedContinueConfig = {
   models: [
     {
       "model": "pearai_model",
-      "contextLength": 200000,
-      "title": "PearAI Server (Recommended)",
+      "contextLength": 128000,
+      "title": "PearAI Server",
+      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
+      "provider": "pearai_server",
+      "isDefault": true
+    },
+    {
+      "model": "gpt-4o",
+      "contextLength": 128000,
+      "title": "GPT-4o",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
       "provider": "pearai_server",
       "isDefault": true
     },
     {
       "model": "claude-3-5-sonnet-20240620",
-      "contextLength": 200000,
+      "contextLength": 128000,
       "title": "Claude 3.5 Sonnet",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
-      "provider": "anthropic",
+      "provider": "pearai_server",
       "isDefault": true
     },
-    {
-      "model": "gpt-4o",
-      "contextLength": 200000,
-      "title": "GPT-4o",
-      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
-      "provider": "openai",
-      "isDefault": true
-    }
   ],
   customCommands: [
     {

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -93,28 +93,31 @@ export const defaultSlashCommandsJetBrains = [
 export const defaultConfig: SerializedContinueConfig = {
   models: [
     {
-      "model": "pearai_model",
-      "contextLength": 128000,
-      "title": "PearAI Server",
-      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
-      "provider": "pearai_server",
-      "isDefault": true
+      model: "pearai_model",
+      contextLength: 128000,
+      title: "pearai-server",
+      systemMessage:
+        "You are an expert software developer. You give helpful and concise responses.",
+      provider: "pearai_server",
+      isDefault: true,
     },
     {
-      "model": "gpt-4o",
-      "contextLength": 128000,
-      "title": "GPT-pear",
-      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
-      "provider": "pearai_server",
-      "isDefault": true
+      model: "gpt-4o",
+      contextLength: 128000,
+      title: "gpt4o-pear",
+      systemMessage:
+        "You are an expert software developer. You give helpful and concise responses.",
+      provider: "pearai_server",
+      isDefault: true,
     },
     {
-      "model": "claude-3-5-sonnet-20240620",
-      "contextLength": 128000,
-      "title": "Claude3.5-pear",
-      "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
-      "provider": "pearai_server",
-      "isDefault": true
+      model: "claude-3-5-sonnet-20240620",
+      contextLength: 128000,
+      title: "claude3.5-pear",
+      systemMessage:
+        "You are an expert software developer. You give helpful and concise responses.",
+      provider: "pearai_server",
+      isDefault: true,
     },
   ],
   customCommands: [

--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -103,7 +103,7 @@ export const defaultConfig: SerializedContinueConfig = {
     {
       "model": "gpt-4o",
       "contextLength": 128000,
-      "title": "GPT-4o",
+      "title": "GPT-pear",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
       "provider": "pearai_server",
       "isDefault": true
@@ -111,7 +111,7 @@ export const defaultConfig: SerializedContinueConfig = {
     {
       "model": "claude-3-5-sonnet-20240620",
       "contextLength": 128000,
-      "title": "Claude 3.5 Sonnet",
+      "title": "Claude3.5-pear",
       "systemMessage": "You are an expert software developer. You give helpful and concise responses.",
       "provider": "pearai_server",
       "isDefault": true

--- a/core/config/load.ts
+++ b/core/config/load.ts
@@ -498,6 +498,7 @@ function finalToBrowserConfig(
       requestOptions: m.requestOptions,
       promptTemplates: m.promptTemplates as any,
       capabilities: m.capabilities,
+      isDefault: m.isDefault,
     })),
     systemMessage: final.systemMessage,
     completionOptions: final.completionOptions,

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -65,6 +65,7 @@ export interface ILLM extends LLMOptions {
   apiKey?: string;
   apiBase?: string;
   refreshToken?: string;
+  isDefault?: boolean;
 
   engine?: string;
   apiVersion?: string;
@@ -330,6 +331,7 @@ export interface LLMOptions {
   aiGatewaySlug?: string;
   apiBase?: string;
   refreshToken?: string;
+  isDefault?: boolean;
 
   useLegacyCompletionsEndpoint?: boolean;
 
@@ -756,7 +758,8 @@ export interface ModelDescription {
   requestOptions?: RequestOptions;
   promptTemplates?: { [key: string]: string };
   capabilities?: ModelCapability;
-  isDefault?: boolean
+  isDefault?: boolean;
+  _llmOptions?: LLMOptions;
 }
 
 export type EmbeddingsProviderName =

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -756,6 +756,7 @@ export interface ModelDescription {
   requestOptions?: RequestOptions;
   promptTemplates?: { [key: string]: string };
   capabilities?: ModelCapability;
+  isDefault?: boolean
 }
 
 export type EmbeddingsProviderName =

--- a/core/index.d.ts
+++ b/core/index.d.ts
@@ -65,7 +65,6 @@ export interface ILLM extends LLMOptions {
   apiKey?: string;
   apiBase?: string;
   refreshToken?: string;
-  isDefault?: boolean;
 
   engine?: string;
   apiVersion?: string;
@@ -759,7 +758,6 @@ export interface ModelDescription {
   promptTemplates?: { [key: string]: string };
   capabilities?: ModelCapability;
   isDefault?: boolean;
-  _llmOptions?: LLMOptions;
 }
 
 export type EmbeddingsProviderName =

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -126,7 +126,6 @@ export abstract class BaseLLM implements ILLM {
     // Set default options
     const options = {
       title: (this.constructor as typeof BaseLLM).providerName,
-      isDefault: (this.constructor as typeof BaseLLM).defaultOptions?.isDefault,
       ...(this.constructor as typeof BaseLLM).defaultOptions,
       ..._options,
     };

--- a/core/llm/index.ts
+++ b/core/llm/index.ts
@@ -98,6 +98,7 @@ export abstract class BaseLLM implements ILLM {
   apiBase?: string;
   capabilities?: ModelCapability
   refreshToken?: string;
+  isDefault?: boolean | undefined;
 
   engine?: string;
   apiVersion?: string;
@@ -125,6 +126,7 @@ export abstract class BaseLLM implements ILLM {
     // Set default options
     const options = {
       title: (this.constructor as typeof BaseLLM).providerName,
+      isDefault: (this.constructor as typeof BaseLLM).defaultOptions?.isDefault,
       ...(this.constructor as typeof BaseLLM).defaultOptions,
       ..._options,
     };
@@ -134,7 +136,7 @@ export abstract class BaseLLM implements ILLM {
 
     const templateType =
       options.template ?? autodetectTemplateType(options.model);
-
+    this.isDefault = options.isDefault;
     this.title = options.title;
     this.uniqueId = options.uniqueId ?? "None";
     this.systemMessage = options.systemMessage;

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -182,7 +182,7 @@ function ModelSelect() {
         return {
           value: model.title,
           title: modelSelectTitle(model),
-          isDefault: model.isDefault
+          isDefault: model?.isDefault
         };
       }),
     );

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -158,6 +158,7 @@ function modelSelectTitle(model: any): string {
 interface Option {
   value: string;
   title: string;
+  isDefault: boolean;
 }
 
 function ModelSelect() {
@@ -181,6 +182,7 @@ function ModelSelect() {
         return {
           value: model.title,
           title: modelSelectTitle(model),
+          isDefault: model.isDefault
         };
       }),
     );
@@ -228,7 +230,7 @@ function ModelSelect() {
               option={option}
               idx={idx}
               key={idx}
-              showDelete={options.length > 1}
+              showDelete={!option.isDefault}
             />
           ))}
 
@@ -263,7 +265,7 @@ function ModelSelect() {
               display: "block",
             }}
           >
-            {getMetaKeyLabel()}' to toggle
+            Press {getMetaKeyLabel()}+' to toggle
           </i>
         </StyledListboxOptions>
       </div>

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -145,7 +145,7 @@ function ModelOption({
 }
 
 function modelSelectTitle(model: any): string {
-  if (model?.title) return model?.title;
+  if (model?.title) return (model.title.toLowerCase().includes("pearai") ? "PearAI" : model?.title);
   if (model?.model !== undefined && model?.model.trim() !== "") {
     if (model?.class_name) {
       return `${model?.class_name} - ${model?.model}`;

--- a/gui/src/components/modelSelection/ModelSelect.tsx
+++ b/gui/src/components/modelSelection/ModelSelect.tsx
@@ -145,7 +145,7 @@ function ModelOption({
 }
 
 function modelSelectTitle(model: any): string {
-  if (model?.title) return (model.title.toLowerCase().includes("pearai") ? "PearAI" : model?.title);
+  if (model?.title) return model?.title;
   if (model?.model !== undefined && model?.model.trim() !== "") {
     if (model?.class_name) {
       return `${model?.class_name} - ${model?.model}`;
@@ -182,7 +182,7 @@ function ModelSelect() {
         return {
           value: model.title,
           title: modelSelectTitle(model),
-          isDefault: model?.isDefault
+          isDefault: model?.isDefault,
         };
       }),
     );


### PR DESCRIPTION
## Description ✏️

- Closes https://github.com/trypear/pearai-app/issues/271

What changed?

- adds 2 default models: gpt and claude supported by pear server
- disables deletion of default models
- addition of isDefault flag to model representation

## Checklist ✅

- [x] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
