### PR TITLE
Remove onboarding's first page

### DIFF
--- a/gui/src/components/Layout.tsx
+++ b/gui/src/components/Layout.tsx
@@ -13,7 +13,10 @@ import {
 } from ".";
 import { IdeMessengerContext } from "../context/IdeMessenger";
 import { useWebviewListener } from "../hooks/useWebviewListener";
-import { shouldBeginOnboarding } from "../pages/onboarding/utils";
+import {
+  shouldBeginOnboarding,
+  useOnboarding,
+} from "../pages/onboarding/utils";
 import { defaultModelSelector } from "../redux/selectors/modelSelectors";
 import {
   setBottomMessage,
@@ -127,6 +130,7 @@ const Layout = () => {
   const location = useLocation();
   const dispatch = useDispatch();
   const ideMessenger = useContext(IdeMessengerContext);
+  const { completeOnboarding } = useOnboarding();
 
   const dialogMessage = useSelector(
     (state: RootState) => state.uiState.dialogMessage,
@@ -243,7 +247,13 @@ const Layout = () => {
       shouldBeginOnboarding() &&
       (location.pathname === "/" || location.pathname === "/index.html")
     ) {
-      navigate("/onboarding");
+      ideMessenger.post("completeOnboarding", {
+        mode: "custom",
+      });
+      console.log("HELLO2");
+      navigate("/addModel/provider/pearai_server", {
+        state: { referrer: "/onboarding" },
+      });
     }
   }, [location]);
 

--- a/gui/src/pages/AddNewModel/ConfigureProvider.tsx
+++ b/gui/src/pages/AddNewModel/ConfigureProvider.tsx
@@ -70,6 +70,7 @@ function ConfigureProvider() {
   const [watsonxAuthenticate, setWatsonxAuthenticate] = React.useState(true);
 
   useEffect(() => {
+    console.log('hello99')
     if (providerName) {
       setModelInfo(providers[providerName]);
     }

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -285,7 +285,7 @@ function GUI() {
           setLocalStorage("ftc", u + 1);
 
           if (u >= FREE_TRIAL_LIMIT_REQUESTS) {
-            navigate("/onboarding");
+            navigate("/addModel/provider/pearai_server");
             posthog?.capture("ftc_reached");
             return;
           }

--- a/gui/src/pages/help.tsx
+++ b/gui/src/pages/help.tsx
@@ -80,7 +80,7 @@ function HelpPage() {
         <TutorialButton
           onClick={() => {
             ideMessenger.post("showTutorial", undefined);
-            navigate("/onboarding");
+            navigate("/addModel/provider/pearai_server");
           }}
         >
           Open Tutorial

--- a/gui/src/pages/onboarding/utils.ts
+++ b/gui/src/pages/onboarding/utils.ts
@@ -38,7 +38,7 @@ export function useOnboarding() {
       setLocalStorage("showTutorialCard", true);
       posthog.capture("Onboarding Step", { status: "Completed" });
     }
-
+    console.log("HELLO1");
     navigate("/");
   };
 


### PR DESCRIPTION
## Description ✏️

**Note** The current PR is incomplete. Anyone can complete this. With the current changes, it goes directly to the configuration page but also constantly switches between the chat and the configuration page, need fix.

When the app first starts, it shows this:
<img width="613" alt="image" src="https://github.com/user-attachments/assets/7eea8392-f1fd-45af-ab65-f9565704df28">

Only after clicking PearAI Server, it goes to the below image:
<img width="580" alt="image" src="https://github.com/user-attachments/assets/71ecf4a3-9ef9-4e98-bf55-78f611b1d05d">


However, we want it to go to the 2nd image right away.

## Solution

- Change onboarding so that it directly shows to login into PearAI
- Change wording: remove "1. Signup at  trypear.ai". It should directly be 

1. Login with PearAI
After login, the [website](https://trypear.ai) should redirect you back here, if it didn't, click again.
If you haven't signed up, do that first and use the "Open PearAI" button on your dashboard after signing in to come back to the app.
[BUTTON HERE THAT SAYS "Login"]
2. Click to complete
[BUTTON THAT SAYS "Use PearAI Server"]


