### PR TITLE
Hide arrows when container expanded

### DIFF
--- a/gui/src/components/ShortcutContainer.tsx
+++ b/gui/src/components/ShortcutContainer.tsx
@@ -87,6 +87,7 @@ const ShortcutContainer = () => {
   const ideMessenger = useContext(IdeMessengerContext);
   const shortcutContainerRef = useRef<HTMLDivElement>(null);
   const [modifier] = useState(isMac ? "Cmd" : "Ctrl");
+  const [showArrows, setShowArrows] = useState(false);
 
   useEffect(() => {
     const shortcutContainer = shortcutContainerRef.current;
@@ -97,9 +98,15 @@ const ShortcutContainer = () => {
           shortcutContainer.scrollLeft += event.deltaY;
         }
       };
+      const checkOverflow = () => {
+        setShowArrows(shortcutContainer.scrollWidth > shortcutContainer.clientWidth);
+      };
       shortcutContainer.addEventListener("wheel", handleWheel);
+      window.addEventListener('resize', checkOverflow);
+
       return () => {
         shortcutContainer.removeEventListener("wheel", handleWheel);
+        window.removeEventListener('resize', checkOverflow);
       };
     }
   }, []);
@@ -151,10 +158,9 @@ const ShortcutContainer = () => {
 
   return (
     <div className="relative h-[1.55rem] overflow-hidden flex justify-center w-full">
-      <LeftArrowButton onClick={scrollLeft}>
+      {showArrows && <LeftArrowButton onClick={scrollLeft}>
         <ChevronLeftIcon />
-      </LeftArrowButton>
-
+      </LeftArrowButton>}
       <div
         ref={shortcutContainerRef}
         className="flex overflow-x-auto whitespace-nowrap no-scrollbar h-full mx-3 max-w-screen-lg"
@@ -170,9 +176,9 @@ const ShortcutContainer = () => {
         ))}
       </div>
 
-      <RightArrowButton onClick={scrollRight}>
+      {showArrows && <RightArrowButton onClick={scrollRight}>
         <ChevronRightIcon />
-      </RightArrowButton>
+      </RightArrowButton>}
     </div>
   );
 };


### PR DESCRIPTION
## Description ✏️

Adds check for the container size, and will render the arrows based on the check.


Closes [#301](https://github.com/trypear/pearai-app/issues/301)

![notexpanded](https://github.com/user-attachments/assets/d2365524-67c7-4b04-8bc7-b656d5626555)
![fix](https://github.com/user-attachments/assets/49f176be-0eec-4575-a214-abd0f670ce1e)

