### PR TITLE
Changed chat input border to PearAI colors

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -33,13 +33,13 @@ const GradientBorder = styled.div<{
       ? props.borderColor
       : `repeating-linear-gradient(
       101.79deg,
-      #1BBE84 0%,
-      #331BBE 16%,
-      #BE1B55 33%,
-      #A6BE1B 55%,
-      #BE1B55 67%,
-      #331BBE 85%,
-      #1BBE84 99%
+      #4DA587 0%,
+      #EBF5DF 16%,
+      #4DA587 33%,
+      #EBF5DF 55%,
+      #4DA587 67%,
+      #4DA587 85%,
+      #4DA587 99%
     )`};
   animation: ${(props) => (props.loading ? gradient : "")} 6s linear infinite;
   background-size: 200% 200%;


### PR DESCRIPTION
## Description ✏️

Closes https://github.com/trypear/pearai-app/issues/311

Changes from the default rainbow border (when chat is streaming to client) to the PearAI color.

https://github.com/user-attachments/assets/eaf2d798-f4aa-4f27-8e68-8602ce0507c5

## Checklist ✅

- [x] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
