### PR TITLE
Add entire file to context when no text is selected

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -90,6 +90,7 @@ async function addHighlightedCodeToContext(
   if (editor) {
     const selection = editor.selection;
     if (selection.isEmpty) {
+      await addEntireFileToContext(editor.document.uri, false, webviewProtocol);
       return;
     }
     // adjust starting position to include indentation


### PR DESCRIPTION
Handles empty selection case
Calls addEntireFileToContext function
Improves user experience
Maintains existing functionality

## Description ✏️



Added addEntireFileToContext to addHighlightedCodeToContext when nothing is selected.

Slightly faster than Ctrl -L , option+enter
allows to start typing with the file

## Checklist ✅

- [x] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).