### PR TITLE
Add preservation of disabled extensions when copying

### DIFF
--- a/extensions/vscode/src/copySettings.ts
+++ b/extensions/vscode/src/copySettings.ts
@@ -38,16 +38,16 @@ function copyVSCodeSettingsToPearAIDir() {
         fs.mkdirSync(pearAIDevExtensionsDir, { recursive: true });
     }
 
-    const itemsToCopy = ['settings.json', 'keybindings.json', 'snippets', 'sync'];
+    const itemsToCopy = ['settings.json', 'keybindings.json', 'snippets', 'sync', 'globalStorage/state.vscdb', 'globalStorage/state.vscdb.backup'];
     itemsToCopy.forEach(item => {
         const source = path.join(vscodeSettingsDir, item);
         const destination = path.join(pearAIDevSettingsDir, item);
         if (fs.existsSync(source)) {
-        if (fs.lstatSync(source).isDirectory()) {
-            copyDirectoryRecursiveSync(source, destination);
-        } else {
-            fs.copyFileSync(source, destination);
-        }
+            if (fs.lstatSync(source).isDirectory()) {
+                copyDirectoryRecursiveSync(source, destination);
+            } else {
+                fs.copyFileSync(source, destination);
+            }
         }
     });
 
@@ -61,7 +61,7 @@ function copyVSCodeSettingsToPearAIDir() {
     }
 
     copyDirectoryRecursiveSync(vscodeExtensionsDir, pearAIDevExtensionsDir, exclusions);
-    }
+}
 
 function getVSCodeSettingsDir() {
     const platform = process.platform;


### PR DESCRIPTION
## Description ✏️

Closes [trypear/pearai-app#338](https://github.com/trypear/pearai-app/issues/338)

What changed? Feel free to be brief.

- Added the file that stores extensions disabled state (state.vscdb, state.vscdb.backup) to be copied from vscode settings
- Minor indentation fixes to copyVSCodeSettingsToPearAIDir function for readability

## Checklist ✅

- [x] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
