### PR TITLE
NOTE: This is not the first PR. We had to perform a refork of the repository, and thus lost the previous 212 closed PRs. Commits can still be seen in history.

### DIFF
--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -301,9 +301,6 @@ export class VsCodeExtension {
         const indexer = await this.core.codebaseIndexerPromise;
         indexer.refreshFile(filepath);
       }
-
-      // Reindex the workspaces
-      this.core.invoke("index/forceReIndex", undefined);
     });
 
     // When GitHub sign-in status changes, reload config


### PR DESCRIPTION
**NOTE: This is not the first PR. We had to perform a refork of the repository, and thus lost the previous 212 closed PRs. Commits can still be seen in history.**

This PR:
fix full reindexing on file save

current behavior is - extensions reindexes entire code base on every file save.
this pr fixes that.