### PR TITLE
Add entire file to context when no text is selected

### DIFF
--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -92,6 +92,7 @@ async function addHighlightedCodeToContext(
   if (editor) {
     const selection = editor.selection;
     if (selection.isEmpty) {
+      await addEntireFileToContext(editor.document.uri, false, webviewProtocol);
       return;
     }
     // adjust starting position to include indentation


### PR DESCRIPTION
https://github.com/trypear/pearai-app/issues/81

**Original PR by @amovfx**
Handles empty selection case
Calls addEntireFileToContext function
Improves user experience
Maintains existing functionality

*Edit by Pan:
**Behaviour wanted**
- Clicking on a file should add the file tag to the chat. E.g., if I click on file pricing.tsx, then @pricing.tsx should appear in the chat prepended. Like below. And the context of that entire file would be prepended to the chat backend.
- This, way it is non obstructive, and user also knows it is there directly.
- When switching opened files, this current file tag would also change.
![image](https://github.com/user-attachments/assets/ebebf302-3fbe-471c-a125-f7a0765b302b)


## Description ✏️

Added addEntireFileToContext to addHighlightedCodeToContext when nothing is selected.

