### PR TITLE
always move chat to secondary sidebar

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -66,12 +66,14 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
 // Custom Layout settings that we want default for PearAPP
 const setupPearAPPLayout = () => {
+  // * always * move pearai extension to auxiliary bar (secondary side bar)
+  vscode.commands.executeCommand("workbench.action.movePearExtensionToAuxBar");
+
+  // Apply the remaining layout settings only on the first launch
   if (isFirstLaunch) {
     return;
   }
 
-  // move pearai extension to auxiliary bar (secondary side bar)
-  vscode.commands.executeCommand("workbench.action.movePearExtensionToAuxBar");
   // set activity bar position to top
   vscode.commands.executeCommand("workbench.action.activityBarLocation.top");
 };


### PR DESCRIPTION
this will move pear extension to secondary sidebar on every launch
requested by pan.
