### PR TITLE
Overlay now doesn't show login onboarding page when already logged in

### DIFF
--- a/gui/src/pages/onboarding/Onboarding.tsx
+++ b/gui/src/pages/onboarding/Onboarding.tsx
@@ -5,7 +5,7 @@ import {
   GiftIcon,
 } from "@heroicons/react/24/outline";
 import { ToCoreFromIdeOrWebviewProtocol } from "core/protocol/core";
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { defaultBorderRadius, lightGray } from "../../components";
@@ -24,6 +24,7 @@ import { providers } from "../AddNewModel/configs/providers";
 import { setDefaultModel } from "../../redux/slices/stateSlice";
 import _ from "lodash";
 import { useWebviewListener } from "../../hooks/useWebviewListener";
+import { setLocalStorage } from "@/util/localStorage";
 
 export const CustomModelButton = styled.div<{ disabled: boolean }>`
   border: 1px solid ${lightGray};
@@ -58,6 +59,7 @@ type OnboardingMode =
 
 function Onboarding() {
   const [hovered, setHovered] = useState(-1);
+  const [session, setSession] = useState(false)
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const ideMessenger = useContext(IdeMessengerContext);
@@ -68,6 +70,19 @@ function Onboarding() {
   >(undefined);
 
   const { completeOnboarding } = useOnboarding();
+
+  useEffect(() => {
+    if (!session) {
+        ideMessenger.request("getPearAuth", undefined).then((res) => {
+          const newSession = res.accessToken ? true : false;
+          setSession(newSession)
+          if (newSession) {
+            setLocalStorage("onboardingStatus", "Completed");
+            completeOnboarding()
+          }
+      });
+    }
+  }, [])
 
   function onSubmit() {
     ideMessenger.post("completeOnboarding", {

--- a/gui/src/redux/slices/miscSlice.ts
+++ b/gui/src/redux/slices/miscSlice.ts
@@ -4,7 +4,7 @@ export const miscSlice = createSlice({
   name: "misc",
   initialState: {
     takenAction: false,
-    serverStatusMessage: "Continue Server Starting",
+    serverStatusMessage: "PearAI Server Starting",
     lastControlServerBetaEnabledStatus: false,
   },
   reducers: {


### PR DESCRIPTION
Used to always show this when already signed in. Now doesn't!
<img width="1869" alt="Screenshot 2024-10-23 at 1 01 36 AM" src="https://github.com/user-attachments/assets/770549e8-1b1e-42a1-a35f-abc1a10b11da">
