### PR TITLE
Fix after login overlay does not change screen + slight refactor

### DIFF
--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -5,16 +5,16 @@ import * as vscode from "vscode";
 import { getExtensionVersion } from "./util/util";
 import { getExtensionUri, getNonce, getUniqueId } from "./util/vscode";
 import { VsCodeWebviewProtocol } from "./webviewProtocol";
-import { PEARAI_CHAT_VIEW_ID } from "./extension/VsCodeExtension";
 
-// The overlay's webview / panel's title is defined in pearai-app's PearOverlayParts.ts
+// The overlay's webview title/id is defined in pearai-app's PearOverlayParts.ts
 // A unique identifier is needed for the messaging protocol to distinguish the webviews.
-const PEAR_OVERLAY_TITLE = "pearai.pearOverlay"
+export const PEAR_OVERLAY_VIEW_ID = "pearai.pearOverlay"
+export const PEAR_CONTINUE_VIEW_ID = "pearai.pearAIChatView";
 
 export class ContinueGUIWebviewViewProvider
   implements vscode.WebviewViewProvider
 {
-  public static readonly viewType = PEARAI_CHAT_VIEW_ID;
+  public static readonly viewType = PEAR_CONTINUE_VIEW_ID;
   public webviewProtocol: VsCodeWebviewProtocol;
   private _webview?: vscode.Webview;
   private _webviewView?: vscode.WebviewView;
@@ -126,7 +126,7 @@ export class ContinueGUIWebviewViewProvider
     isFullScreen = false,
     initialRoute: string = "/"
   ): string {
-    const isOverlay = panel?.title === PEAR_OVERLAY_TITLE; // defined in pearai-app PearOverlayPart.ts
+    const isOverlay = panel?.title === PEAR_OVERLAY_VIEW_ID; // defined in pearai-app PearOverlayPart.ts
     const extensionUri = getExtensionUri();
     let scriptUri: string;
     let styleMainUri: string;
@@ -176,7 +176,7 @@ export class ContinueGUIWebviewViewProvider
       }
     });
 
-    this.webviewProtocol.addWebview(panel?.title === PEAR_OVERLAY_TITLE? panel.title : panel.viewType, panel.webview);
+    this.webviewProtocol.addWebview(panel?.title === PEAR_OVERLAY_VIEW_ID? panel.title : panel.viewType, panel.webview);
 
     return `<!DOCTYPE html>
     <html lang="en">

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -22,7 +22,7 @@ import {
   quickPickStatusText,
   setupStatusBar,
 } from "./autocomplete/statusBar";
-import { ContinueGUIWebviewViewProvider } from "./ContinueGUIWebviewViewProvider";
+import { ContinueGUIWebviewViewProvider, PEAR_OVERLAY_VIEW_ID } from "./ContinueGUIWebviewViewProvider";
 import { DiffManager } from "./diff/horizontal";
 import { VerticalPerLineDiffManager } from "./diff/verticalPerLine/manager";
 import { QuickEdit, QuickEditShowParams } from "./quickEdit/QuickEditQuickPick";
@@ -31,6 +31,7 @@ import type { VsCodeWebviewProtocol } from "./webviewProtocol";
 import { getExtensionUri } from "./util/vscode";
 import { handleAiderMode } from './integrations/aider/aider';
 import { handlePerplexityMode } from "./integrations/perplexity/perplexity";
+import { PEAR_CONTINUE_VIEW_ID } from "./ContinueGUIWebviewViewProvider";
 
 
 let fullScreenPanel: vscode.WebviewPanel | undefined;
@@ -764,7 +765,8 @@ const commandsMap: (
       extensionContext.secrets.store("pearai-token", data.accessToken);
       extensionContext.secrets.store("pearai-refresh", data.refreshToken);
       core.invoke("llm/resetPearAICredentials", undefined);
-      sidebar.webviewProtocol?.request("addPearAIModel", undefined, ["pearai.pearAIChatView"]);
+      sidebar.webviewProtocol?.request("addPearAIModel", undefined, [PEAR_CONTINUE_VIEW_ID]);
+      sidebar.webviewProtocol?.request("addPearAIModel", undefined, [PEAR_OVERLAY_VIEW_ID]);
       vscode.window.showInformationMessage("PearAI: Successfully logged in!");
     },
     "pearai.closeChat": () => {

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -16,7 +16,7 @@ import {
   StatusBarStatus,
 } from "../autocomplete/statusBar";
 import { registerAllCommands } from "../commands";
-import { ContinueGUIWebviewViewProvider } from "../ContinueGUIWebviewViewProvider";
+import { ContinueGUIWebviewViewProvider, PEAR_CONTINUE_VIEW_ID } from "../ContinueGUIWebviewViewProvider";
 import { registerDebugTracker } from "../debug/debug";
 import { DiffManager } from "../diff/horizontal";
 import { VerticalPerLineDiffManager } from "../diff/verticalPerLine/manager";
@@ -32,8 +32,6 @@ import { Battery } from "../util/battery";
 import { TabAutocompleteModel } from "../util/loadAutocompleteModel";
 import type { VsCodeWebviewProtocol } from "../webviewProtocol";
 import { VsCodeMessenger } from "./VsCodeMessenger";
-
-export const PEARAI_CHAT_VIEW_ID = "pearai.pearAIChatView";
 
 export class VsCodeExtension {
   // Currently some of these are public so they can be used in testing (test/test-suites)
@@ -89,7 +87,7 @@ export class VsCodeExtension {
     // Sidebar + Overlay
     context.subscriptions.push(
       vscode.window.registerWebviewViewProvider(
-        PEARAI_CHAT_VIEW_ID,
+        PEAR_CONTINUE_VIEW_ID,
         this.sidebar,
         {
           webviewOptions: { retainContextWhenHidden: true },

--- a/gui/src/pages/onboarding/Onboarding.tsx
+++ b/gui/src/pages/onboarding/Onboarding.tsx
@@ -1,24 +1,15 @@
-import {
-  CheckBadgeIcon,
-  Cog6ToothIcon,
-  ComputerDesktopIcon,
-  GiftIcon,
-} from "@heroicons/react/24/outline";
-import { ToCoreFromIdeOrWebviewProtocol } from "core/protocol/core";
 import { useContext, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { defaultBorderRadius, lightGray } from "../../components";
 import ConfirmationDialog from "../../components/dialogs/ConfirmationDialog";
-import GitHubSignInButton from "../../components/modelSelection/quickSetup/GitHubSignInButton";
 import { IdeMessengerContext } from "../../context/IdeMessenger";
 import {
   setDialogMessage,
   setShowDialog,
 } from "../../redux/slices/uiStateSlice";
-import { Div, StyledButton } from "./components";
+import { StyledButton } from "./components";
 import { useOnboarding } from "./utils";
-import { greenButtonColor } from "../../components";
 import styled from "styled-components";
 import { providers } from "../AddNewModel/configs/providers";
 import { setDefaultModel } from "../../redux/slices/stateSlice";
@@ -49,26 +40,11 @@ export const CustomModelButton = styled.div<{ disabled: boolean }>`
   `}
 `;
 
-enum ModelType {
-  PearAI,
-  Other,
-}
-
-type OnboardingMode =
-  ToCoreFromIdeOrWebviewProtocol["completeOnboarding"][0]["mode"];
-
 function Onboarding() {
-  const [hovered, setHovered] = useState(-1);
   const [session, setSession] = useState(false)
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const ideMessenger = useContext(IdeMessengerContext);
-
-  const [hasSignedIntoGh, setHasSignedIntoGh] = useState(false);
-  const [selectedOnboardingMode, setSlectedOnboardingMode] = useState<
-    OnboardingMode | undefined
-  >(undefined);
-
   const { completeOnboarding } = useOnboarding();
 
   useEffect(() => {
@@ -83,42 +59,6 @@ function Onboarding() {
       });
     }
   }, [])
-
-  function onSubmit() {
-    ideMessenger.post("completeOnboarding", {
-      mode: "custom",
-    });
-
-    /**
-     * "completeOnboarding" above will update the config with our
-     * new embeddings provider. If it's not the default local provider,
-     * we need to re-index the codebase.
-     */
-    if (selectedOnboardingMode !== "local") {
-      ideMessenger.post("index/forceReIndex", undefined);
-    }
-  }
-
-  const handleSelect = (selectedModel: ModelType) => {
-    ideMessenger.post("completeOnboarding", {
-      mode: "custom",
-    });
-
-    switch (selectedModel) {
-      case ModelType.PearAI:
-        navigate("/addModel/provider/pearai_server", {
-          state: { referrer: "/onboarding" },
-        });
-        break;
-      case ModelType.Other:
-        navigate("/addModel/provider", {
-          state: { showOtherProviders: true, referrer: "/onboarding" },
-        });
-        break;
-      default:
-        break;
-    }
-  };
 
   const modelInfo = providers["pearai_server"];
 
@@ -191,29 +131,6 @@ function Onboarding() {
         </a>
         .
       </small>
-      {/* <div>
-        <Div
-          selected={false}
-          onClick={() => handleSelect(ModelType.PearAI)}
-          onMouseEnter={() => setHovered(ModelType.PearAI)}
-          onMouseLeave={() => setHovered(-1)}
-        >
-          <div className="flex items-center">
-            <img
-              src={`${window.vscMediaUrl}/logos/pearai-color.png`}
-              className="mr-1"
-              height="24px"
-            ></img>
-            <h3>PearAI Server </h3>
-          </div>
-          <p className="mt-0">
-            Convenient, fully-managed integration, with the current
-            best-in-market language models.
-          </p>
-          <p className="mt-0">Code is not stored.</p>
-        </Div>
-        <br></br>
-      </div> */}
       <div className="absolute bottom-4 right-4">
         <StyledButton
           onClick={(e) => {


### PR DESCRIPTION
Before:
- After log in success, still shows log in screen in overlay. Because the success login event is only sent to sidebar chat.

After
- Event sent to both sidebar and overlay. So overlay navigates to "/" path as well after success login

Refactor
- Removed some unused code
- Formalize the view ids for both overlay and continue chat. need to replace in other parts of the code as well in different dedicated refactor PR.