### PR TITLE
Skip login for overlay view

### DIFF
--- a/gui/src/pages/onboarding/Onboarding.tsx
+++ b/gui/src/pages/onboarding/Onboarding.tsx
@@ -48,15 +48,9 @@ function Onboarding() {
   const { completeOnboarding } = useOnboarding();
 
   useEffect(() => {
-    if (!session) {
-        ideMessenger.request("getPearAuth", undefined).then((res) => {
-          const newSession = res.accessToken ? true : false;
-          setSession(newSession)
-          if (newSession) {
-            setLocalStorage("onboardingStatus", "Completed");
-            completeOnboarding()
-          }
-      });
+    if (window.isPearOverlay) {
+      // Overlay can skip login step because user will login from sidebar
+      navigate("/")
     }
   }, [])
 


### PR DESCRIPTION
Context:
If the overlay is hidden, it will not be able to receive or post messages (e.g. login complete), unless we have retainContextWhenHidden: true, in the panel/webview creation (or set during resolving). Current workaround: overlay can always skip the login screen until we set proper onboarding to be completely within the overlay.

It is best to not set the retain context when hidden to be true unless necessary, because it increases memory usage.

Overlay signin view is not necessary for now since users are expected to see the sidebar first where they sign in. Then the token is stored and user can chat from overlay too.