### PR TITLE
Fix context providers of overlay search

### DIFF
--- a/gui/src/integrations/util/integrationSpecificContextProviders.ts
+++ b/gui/src/integrations/util/integrationSpecificContextProviders.ts
@@ -18,6 +18,8 @@ const SPECIFIC_CONTEXT_PROVIDERS_INTEGRATIONS = {
 const SPECIFIC_CONTEXT_PROVIDERS_PATHNAME = {
   "/aiderMode": aiderContextProvidersSpecific,
   "/perplexityMode": perplexityContextProvidersSpecific,
+  "/inventory/aiderMode": aiderContextProvidersSpecific,
+  "/inventory/perplexityMode": perplexityContextProvidersSpecific,
 };
 
 export function shouldSkipContextProviders(
@@ -41,10 +43,10 @@ export function shouldSkipContextProviders(
   // For all other models, only skip if "relativefilecontext"
   return description.title === "relativefilecontext";
 }
-
 export function getContextProviders() {
   let location = useLocation();
   let pathname = location.pathname;
+  const lastPartOfPath = `/${pathname.split("/").pop() ?? pathname}`;
   let availableContextProviders = useSelector(
     (store: RootState) => store.state.config.contextProviders,
   );

--- a/gui/src/integrations/util/integrationSpecificContextProviders.ts
+++ b/gui/src/integrations/util/integrationSpecificContextProviders.ts
@@ -46,7 +46,6 @@ export function shouldSkipContextProviders(
 export function getContextProviders() {
   let location = useLocation();
   let pathname = location.pathname;
-  const lastPartOfPath = `/${pathname.split("/").pop() ?? pathname}`;
   let availableContextProviders = useSelector(
     (store: RootState) => store.state.config.contextProviders,
   );

--- a/gui/src/inventory/pages/InventoryPage.tsx
+++ b/gui/src/inventory/pages/InventoryPage.tsx
@@ -135,7 +135,10 @@ const initialTools: AITool[] = [
       <span>Lower level of human intervention needed</span>,
     ],
     weaknesses: [
-      <span>Less control over code changes as they are instantly applied</span>,
+      <span>
+        Less control over code changes during generation as they are instantly
+        applied
+      </span>,
     ],
     enabled: true,
   },


### PR DESCRIPTION
Now only file, terminal and folder should appear as context providers for search.