### PR TITLE
Fix: Use `Mod` key instead of `Cmd` for multi-platform compatibility

### DIFF
--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -362,7 +362,7 @@ function TipTapEditor({
               return true;
             },
 
-            "Cmd-Enter": () => {
+            "Mod-Enter": () => {
               onEnterRef.current({
                 useCodebase: true,
                 noContext: !useActiveFile,
@@ -379,7 +379,7 @@ function TipTapEditor({
 
               return true;
             },
-            "Cmd-Backspace": () => {
+            "Mod-Backspace": () => {
               // If you press cmd+backspace wanting to cancel,
               // but are inside of a text box, it shouldn't
               // delete the text


### PR DESCRIPTION
The `Cmd` key is specific to macOS, while `Mod` is cross-platform. This change ensures that the keybinding works correctly on both macOS and Windows.

## Description ✏️

Works for Windows now.

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).
