### PR TITLE
Add current active file to context by default

### DIFF
--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -51,7 +51,7 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
 
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setInactive: [undefined, void];
-  setActiveFilePath: [string, void];
+  setActiveFilePath: [string | undefined, void];
   resetInteractiveContinueTutorial: [undefined, void];
   showInteractiveContinueTutorial: [undefined, void];
   submitMessage: [{ message: any }, void]; // any -> JSONContent from TipTap

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -51,6 +51,7 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
 
 export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setInactive: [undefined, void];
+  setActiveFilePath: [string, void];
   resetInteractiveContinueTutorial: [undefined, void];
   showInteractiveContinueTutorial: [undefined, void];
   submitMessage: [{ message: any }, void]; // any -> JSONContent from TipTap

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -555,8 +555,10 @@ const commandsMap: (
       captureCommandTelemetry("sendToTerminal");
       ide.runCommand(text);
     },
-    "pearai.newSession": () => {
+    "pearai.newSession": async () => {
       sidebar.webviewProtocol?.request("newSession", undefined);
+      const currentFile = await ide.getCurrentFile();
+      sidebar.webviewProtocol?.request("setActiveFilePath", currentFile, [PEAR_CONTINUE_VIEW_ID]);
     },
     "pearai.viewHistory": () => {
       sidebar.webviewProtocol?.request("viewHistory", undefined, [

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -369,6 +369,10 @@ export class VsCodeExtension {
 
     this.ide.onDidChangeActiveTextEditor((filepath) => {
       this.core.invoke("didChangeActiveTextEditor", { filepath });
+
+      if (filepath) {
+        this.sidebar.webviewProtocol.request("setActiveFilePath", filepath, [PEAR_CONTINUE_VIEW_ID]);
+      }
     });
 
     startAiderProcess(this.core);

--- a/extensions/vscode/src/extension/VsCodeExtension.ts
+++ b/extensions/vscode/src/extension/VsCodeExtension.ts
@@ -369,10 +369,7 @@ export class VsCodeExtension {
 
     this.ide.onDidChangeActiveTextEditor((filepath) => {
       this.core.invoke("didChangeActiveTextEditor", { filepath });
-
-      if (filepath) {
-        this.sidebar.webviewProtocol.request("setActiveFilePath", filepath, [PEAR_CONTINUE_VIEW_ID]);
-      }
+      this.sidebar.webviewProtocol.request("setActiveFilePath", filepath, [PEAR_CONTINUE_VIEW_ID]);
     });
 
     startAiderProcess(this.core);

--- a/gui/src/components/mainInput/ActiveFileIndicator.tsx
+++ b/gui/src/components/mainInput/ActiveFileIndicator.tsx
@@ -1,0 +1,34 @@
+import { RootState } from "@/redux/store";
+import { useDispatch, useSelector } from "react-redux";
+import { IdeMessengerContext } from "@/context/IdeMessenger";
+import { useContext } from "react";
+import { X } from "lucide-react";
+import { setActiveFilePath } from "@/redux/slices/uiStateSlice";
+
+export default function ActiveFileIndicator() {
+  const activeFilePath = useSelector((state: RootState) => state.uiState.activeFilePath);
+  const fileName = activeFilePath?.split(/[/\\]/)?.pop() ?? activeFilePath;
+  const ideMessenger = useContext(IdeMessengerContext);
+  const dispatch = useDispatch();
+  
+  const remove = () => {
+    dispatch(setActiveFilePath(undefined));
+  }
+    
+  if (!activeFilePath) return null;
+
+  return (
+    <div className="flex gap-1 mb-3 text-xs items-center">
+      <span>Current file: </span>
+        <span className="mention cursor-pointer flex items-center gap-[0.15rem]">
+          <span
+          onClick={() => {
+            ideMessenger.post("openFile", { path: activeFilePath });
+          }}>
+            {`@${fileName}`}
+          </span>
+          <X className="text-xs pt-[0.15rem] pr-[0.1rem]" size={9} onClick={() => remove()}/>
+        </span>
+    </div>
+  );
+};

--- a/gui/src/components/mainInput/ActiveFileIndicator.tsx
+++ b/gui/src/components/mainInput/ActiveFileIndicator.tsx
@@ -1,7 +1,7 @@
 import { RootState } from "@/redux/store";
 import { useDispatch, useSelector } from "react-redux";
 import { IdeMessengerContext } from "@/context/IdeMessenger";
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 import { X } from "lucide-react";
 import { setActiveFilePath } from "@/redux/slices/uiStateSlice";
 
@@ -11,14 +11,14 @@ export default function ActiveFileIndicator() {
   const ideMessenger = useContext(IdeMessengerContext);
   const dispatch = useDispatch();
   
-  const remove = () => {
+  const removeActiveFile = useCallback(() => {
     dispatch(setActiveFilePath(undefined));
-  }
+  }, [])
     
   if (!activeFilePath) return null;
 
   return (
-    <div className="flex gap-1 mb-3 text-xs items-center">
+    <div className="flex gap-1 mb-2 text-xs items-center">
       <span>Current file: </span>
         <span className="mention cursor-pointer flex items-center gap-[0.15rem]">
           <span
@@ -27,7 +27,7 @@ export default function ActiveFileIndicator() {
           }}>
             {`@${fileName}`}
           </span>
-          <X className="text-xs pt-[0.15rem] pr-[0.1rem]" size={9} onClick={() => remove()}/>
+          <X className="text-xs pt-[0.15rem] pr-[0.1rem]" size={9} onClick={removeActiveFile}/>
         </span>
     </div>
   );

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -656,14 +656,6 @@ const TipTapEditor = memo(function TipTapEditor({
   );
 
   useWebviewListener(
-    "setActiveFilePath",
-    async (data) => {
-      historyLength < 1 && dispatch(setActiveFilePath(data));
-    },
-    [dispatch]
-  );
-
-  useWebviewListener(
     "addPerplexityContextinChat",
     async (data) => {
       if (!isMainInput || !editor) {

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -57,6 +57,8 @@ import {
 } from "./getSuggestion";
 import { ComboBoxItem } from "./types";
 import { useLocation } from "react-router-dom";
+import ActiveFileIndicator from "./ActiveFileIndicator";
+import { setActiveFilePath } from "@/redux/slices/uiStateSlice";
 
 
 const InputBoxDiv = styled.div`
@@ -192,6 +194,8 @@ const TipTapEditor = memo(function TipTapEditor({
   const editorKey = useMemo(() => `${(source || 'continue')}-editor`, [source]);
 
   const useActiveFile = useSelector(selectUseActiveFile);
+  const activeFilePath = useSelector((state: RootState) => state.uiState.activeFilePath);
+  const useActiveFileFinal = !!(useActiveFile || activeFilePath)
 
   const { saveSession } = useHistory(dispatch, source);
 
@@ -367,7 +371,7 @@ const TipTapEditor = memo(function TipTapEditor({
 
               onEnterRef.current({
                 useCodebase: false,
-                noContext: !useActiveFile,
+                noContext: !useActiveFileFinal,
               });
               return true;
             },
@@ -375,7 +379,7 @@ const TipTapEditor = memo(function TipTapEditor({
             "Mod-Enter": () => {
               onEnterRef.current({
                 useCodebase: true,
-                noContext: !useActiveFile,
+                noContext: !useActiveFileFinal,
               });
               return true;
             },
@@ -384,7 +388,7 @@ const TipTapEditor = memo(function TipTapEditor({
 
               onEnterRef.current({
                 useCodebase: false,
-                noContext: useActiveFile,
+                noContext: useActiveFileFinal,
               });
 
               return true;
@@ -651,6 +655,14 @@ const TipTapEditor = memo(function TipTapEditor({
       onEnterRef.current({ useCodebase: false, noContext: true });
     },
     [editor, onEnterRef.current, isMainInput],
+  );
+
+  useWebviewListener(
+    "setActiveFilePath",
+    async (data) => {
+      historyLength < 1 && dispatch(setActiveFilePath(data));
+    },
+    [dispatch]
   );
 
   useWebviewListener(
@@ -963,6 +975,7 @@ const TipTapEditor = memo(function TipTapEditor({
         event.preventDefault();
       }}
     >
+      {historyLength === 0 && <ActiveFileIndicator />}
       <EditorContent
         spellCheck={false}
         editor={editor}

--- a/gui/src/components/mainInput/TipTapEditor.tsx
+++ b/gui/src/components/mainInput/TipTapEditor.tsx
@@ -194,8 +194,6 @@ const TipTapEditor = memo(function TipTapEditor({
   const editorKey = useMemo(() => `${(source || 'continue')}-editor`, [source]);
 
   const useActiveFile = useSelector(selectUseActiveFile);
-  const activeFilePath = useSelector((state: RootState) => state.uiState.activeFilePath);
-  const useActiveFileFinal = !!(useActiveFile || activeFilePath)
 
   const { saveSession } = useHistory(dispatch, source);
 
@@ -371,7 +369,7 @@ const TipTapEditor = memo(function TipTapEditor({
 
               onEnterRef.current({
                 useCodebase: false,
-                noContext: !useActiveFileFinal,
+                noContext: !useActiveFile,
               });
               return true;
             },
@@ -379,7 +377,7 @@ const TipTapEditor = memo(function TipTapEditor({
             "Mod-Enter": () => {
               onEnterRef.current({
                 useCodebase: true,
-                noContext: !useActiveFileFinal,
+                noContext: !useActiveFile,
               });
               return true;
             },
@@ -388,7 +386,7 @@ const TipTapEditor = memo(function TipTapEditor({
 
               onEnterRef.current({
                 useCodebase: false,
-                noContext: useActiveFileFinal,
+                noContext: useActiveFile,
               });
 
               return true;

--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -183,11 +183,8 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger, source:
         ideMessenger,
       );
 
-      console.dir(`TEST: Use active file? ${useActiveFile}`);
-      console.dir(`TEST: !noContext? ${!modifiers.noContext}, useActiveFile? ${useActiveFile}, history.length? ${history.length}, index? ${index}`);
-      console.dir(`TEST: IF Condition: ${(!modifiers.noContext || useActiveFile) && (history.length === 0 || index === 0)}`)
       // Automatically use currently open file
-      if ((!modifiers.noContext || useActiveFile) && (history.length === 0 || index === 0)) {
+      if (source === 'continue' && (!modifiers.noContext || useActiveFile) && (history.length === 0 || index === 0)) {
         console.dir("TEST: USING ACTIVE FILE")
         const usingFreeTrial = defaultModel.provider === "free-trial";
 

--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -41,6 +41,7 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger, source:
   const posthog = usePostHog();
 
   const defaultModel = useSelector(defaultModelSelector);
+  const useActiveFile = !!(useSelector((state: RootState) => state.uiState.activeFilePath));
 
   const slashCommands = useSelector(
     (store: RootState) => store.state.config.slashCommands || [],
@@ -182,8 +183,12 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger, source:
         ideMessenger,
       );
 
+      console.dir(`TEST: Use active file? ${useActiveFile}`);
+      console.dir(`TEST: !noContext? ${!modifiers.noContext}, useActiveFile? ${useActiveFile}, history.length? ${history.length}, index? ${index}`);
+      console.dir(`TEST: IF Condition: ${(!modifiers.noContext || useActiveFile) && (history.length === 0 || index === 0)}`)
       // Automatically use currently open file
-      if (!modifiers.noContext && (history.length === 0 || index === 0)) {
+      if ((!modifiers.noContext || useActiveFile) && (history.length === 0 || index === 0)) {
+        console.dir("TEST: USING ACTIVE FILE")
         const usingFreeTrial = defaultModel.provider === "free-trial";
 
         const currentFilePath = await ideMessenger.ide.getCurrentFile();

--- a/gui/src/hooks/useChatHandler.ts
+++ b/gui/src/hooks/useChatHandler.ts
@@ -185,7 +185,6 @@ function useChatHandler(dispatch: Dispatch, ideMessenger: IIdeMessenger, source:
 
       // Automatically use currently open file
       if (source === 'continue' && (!modifiers.noContext || useActiveFile) && (history.length === 0 || index === 0)) {
-        console.dir("TEST: USING ACTIVE FILE")
         const usingFreeTrial = defaultModel.provider === "free-trial";
 
         const currentFilePath = await ideMessenger.ide.getCurrentFile();

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -52,6 +52,7 @@ import {
 import { FREE_TRIAL_LIMIT_REQUESTS } from "../util/freeTrial";
 import { getLocalStorage, setLocalStorage } from "../util/localStorage";
 import OnboardingTutorial from "./onboarding/OnboardingTutorial";
+import { setActiveFilePath } from "@/redux/slices/uiStateSlice";
 
 export const TopGuiDiv = styled.div`
   overflow-y: scroll;
@@ -273,6 +274,14 @@ function GUI() {
       mainTextInputRef.current?.focus?.();
     },
     [saveSession],
+  );
+
+  useWebviewListener(
+    "setActiveFilePath",
+    async (data) => {
+      dispatch(setActiveFilePath(data));
+    },
+    []
   );
 
   useWebviewListener(

--- a/gui/src/redux/slices/uiStateSlice.ts
+++ b/gui/src/redux/slices/uiStateSlice.ts
@@ -6,6 +6,7 @@ type UiState = {
   showDialog: boolean;
   dialogMessage: string | JSX.Element;
   dialogEntryOn: boolean;
+  activeFilePath: string | undefined;
 };
 
 export const uiStateSlice = createSlice({
@@ -17,6 +18,7 @@ export const uiStateSlice = createSlice({
     dialogMessage: "",
     dialogEntryOn: false,
     displayBottomMessageOnBottom: true,
+    activeFilePath: undefined,
   } as UiState,
   reducers: {
     setBottomMessage: (
@@ -55,6 +57,9 @@ export const uiStateSlice = createSlice({
     ) => {
       state.displayBottomMessageOnBottom = action.payload;
     },
+    setActiveFilePath: (state, action: PayloadAction<UiState["activeFilePath"]>) => {
+      state.activeFilePath = action.payload;
+    },
   },
 });
 
@@ -65,5 +70,6 @@ export const {
   setDialogEntryOn,
   setShowDialog,
   setDisplayBottomMessageOnBottom,
+  setActiveFilePath,
 } = uiStateSlice.actions;
 export default uiStateSlice.reducer;


### PR DESCRIPTION
PR Based upon @charlwillia6 's PR: https://github.com/trypear/pearai-submodule/pull/127/files

Automatically add current file to context on first prompt
- Subsequent chats will not re-add current file
- Changing file will update current active file
- Removing current active file, then changing files will put new one.
- Only for Continue sidebar chat

<img width="469" alt="Screenshot 2024-11-08 at 2 50 50 AM" src="https://github.com/user-attachments/assets/dd8b47e4-1217-45a2-9c5e-c7d573f828f5">

Need to test the following:

- [x] - Changing files
- [x] - Writing something and changing files (should keep changing)
- [x] - CMD+L with portion of code or slash command then changing files
- [x] - Same file, deleting current file context, pressing file and going back to chat should not re-add.
- [x] - Same file, deleting current context, going to different ifle and coming back should re-add.
- [x] - Chatting in current, then subsequent chats should not tag anymore.
- [x] - New chat: should have context
- [x] - Opening previous chats from history, should not have context
- [x] - putting a slash command
- [x] - if an error, does it remove prompt? should not remove