### PR TITLE
Remove annual for o1s

### DIFF
--- a/core/config/default.ts
+++ b/core/config/default.ts
@@ -157,13 +157,13 @@ export const defaultConfig: SerializedContinueConfig = {
     },
     {
       model: "o1-mini",
-      title: "GPTo1 Mini (PearAI annual only)",
+      title: "GPT o1-mini",
       provider: "pearai_server",
       isDefault: true,
     },
     {
       model: "o1-preview",
-      title: "GPTo1 Preview (PearAI annual only)",
+      title: "GPT o1-preview (high cost)",
       provider: "pearai_server",
       isDefault: true,
     },


### PR DESCRIPTION
## Description ✏️

Closes #xxx

What changed? Feel free to be brief.

- Bullet points are helpful.
- Screenshots are helpful (if applicable).

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update model titles in `defaultConfig` to remove 'annual' mention for `o1-mini` and `o1-preview`.
> 
>   - **Behavior**:
>     - Updated `title` for `o1-mini` model from "GPTo1 Mini (PearAI annual only)" to "GPT o1-mini" in `defaultConfig`.
>     - Updated `title` for `o1-preview` model from "GPTo1 Preview (PearAI annual only)" to "GPT o1-preview (high cost)" in `defaultConfig`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 2b8fe64c2a58880e8731cbf970b9cdfe74721fbd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->