### PR TITLE
Perplexity history chat bug fix

### DIFF
--- a/gui/src/integrations/perplexity/perplexitygui.tsx
+++ b/gui/src/integrations/perplexity/perplexitygui.tsx
@@ -220,6 +220,13 @@ function PerplexityGUI() {
     [state.perplexityHistory],
   );
 
+  const [historyKey, setHistoryKey] = useState(0);
+
+  // force re-render continueInputBox when history changes
+  useEffect(() => {
+    setHistoryKey(prev => prev + 1);
+  }, [state.perplexityHistory]);
+
   return (
     <>
     <div className="relative flex h-screen overflow-hidden">
@@ -328,6 +335,7 @@ function PerplexityGUI() {
                 >
                   {item.message.role === "user" ? (
                     <ContinueInputBox
+                      key={historyKey}
                       onEnter={async (editorState, modifiers) => {
                         streamResponse(
                           editorState,


### PR DESCRIPTION
## Description ✏️

Closes #xxx

What changed? Feel free to be brief.

- Bullet points are helpful.
- Screenshots are helpful (if applicable).

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes re-rendering bug in `PerplexityGUI` by adding `historyKey` state to force `ContinueInputBox` re-render on `perplexityHistory` changes.
> 
>   - **Behavior**:
>     - Fixes bug in `PerplexityGUI` where `ContinueInputBox` did not re-render on `perplexityHistory` changes by adding `historyKey` state.
>     - `useEffect` added to increment `historyKey` on `perplexityHistory` updates.
>   - **Components**:
>     - `ContinueInputBox` now uses `key={historyKey}` to force re-render.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 38fde87ad7fad771213ff8ec760ec509c62ddf47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->