### PR TITLE
focus editor on new session and history load

### DIFF
--- a/gui/src/integrations/aider/aidergui.tsx
+++ b/gui/src/integrations/aider/aidergui.tsx
@@ -52,6 +52,7 @@ function AiderGUI() {
   const navigate = useNavigate();
   const ideMessenger = useContext(IdeMessengerContext);
 
+  const [sessionKey, setSessionKey] = useState(0);
   const sessionState = useSelector((state: RootState) => state.state);
   const defaultModel = useSelector(defaultModelSelector);
   const active = useSelector((state: RootState) => state.state.aiderActive);
@@ -195,7 +196,7 @@ function AiderGUI() {
     "newSession",
     async () => {
       saveSession();
-      mainTextInputRef.current?.focus?.();
+      setSessionKey(prev => prev + 1);
     },
     [saveSession],
   );
@@ -387,6 +388,7 @@ useEffect(() => {
                       onClick={() => {
                         saveSession();
                         ideMessenger.post("aiderResetSession", undefined);
+                        setSessionKey(prev => prev + 1);
                       }}
                       className="mr-auto"
                     >
@@ -511,6 +513,7 @@ useEffect(() => {
               )}
             >
               <ContinueInputBox
+                key={sessionKey}
                 onEnter={(editorContent, modifiers) => {
                   sendInput(editorContent, modifiers);
                 }}
@@ -537,6 +540,7 @@ useEffect(() => {
                 onClick={() => {
                   saveSession();
                   ideMessenger.post("aiderResetSession", undefined);
+                  setSessionKey(prev => prev + 1);
                 }}
                 className="mr-auto"
               >

--- a/gui/src/integrations/perplexity/perplexitygui.tsx
+++ b/gui/src/integrations/perplexity/perplexitygui.tsx
@@ -194,7 +194,7 @@ function PerplexityGUI() {
     "newSession",
     async () => {
       saveSession();
-      setSessionKey(prev => prev + 1); // Add this
+      setSessionKey(prev => prev + 1);
     },
     [saveSession],
   );
@@ -203,7 +203,7 @@ function PerplexityGUI() {
     "loadMostRecentChat",
     async () => {
       await loadMostRecentChat();
-      setSessionKey(prev => prev + 1); // Add this
+      setSessionKey(prev => prev + 1);
     },
     [loadMostRecentChat],
   );

--- a/gui/src/integrations/perplexity/perplexitygui.tsx
+++ b/gui/src/integrations/perplexity/perplexitygui.tsx
@@ -188,11 +188,13 @@ function PerplexityGUI() {
   const { saveSession, getLastSessionId, loadLastSession, loadMostRecentChat } =
     useHistory(dispatch, "perplexity");
 
+  const [sessionKey, setSessionKey] = useState(0);
+
   useWebviewListener(
     "newSession",
     async () => {
       saveSession();
-      mainTextInputRef.current?.focus?.();
+      setSessionKey(prev => prev + 1); // Add this
     },
     [saveSession],
   );
@@ -201,7 +203,7 @@ function PerplexityGUI() {
     "loadMostRecentChat",
     async () => {
       await loadMostRecentChat();
-      mainTextInputRef.current?.focus?.();
+      setSessionKey(prev => prev + 1); // Add this
     },
     [loadMostRecentChat],
   );
@@ -225,6 +227,7 @@ function PerplexityGUI() {
   // force re-render continueInputBox when history changes
   useEffect(() => {
     setHistoryKey(prev => prev + 1);
+    setSessionKey(prev => prev + 1);
   }, [state.perplexityHistory]);
 
   return (
@@ -311,7 +314,7 @@ function PerplexityGUI() {
                   <NewSessionButton
                     onClick={() => {
                       saveSession();
-                      ideMessenger.post("aiderResetSession", undefined);
+                      setSessionKey(prev => prev + 1);
                     }}
                     className="mr-auto"
                   >
@@ -438,6 +441,7 @@ function PerplexityGUI() {
             )}
           >
             <ContinueInputBox
+              key={sessionKey}
               onEnter={(editorContent, modifiers) => {
                 sendInput(editorContent, modifiers);
               }}
@@ -461,6 +465,7 @@ function PerplexityGUI() {
               <NewSessionButton
                 onClick={() => {
                   saveSession();
+                  setSessionKey(prev => prev + 1);
                 }}
                 className="mr-auto"
               >


### PR DESCRIPTION
## Description ✏️

Closes #xxx

What changed? Feel free to be brief.

- Bullet points are helpful.
- Screenshots are helpful (if applicable).

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor `AiderGUI` and `PerplexityGUI` to use `sessionKey` for re-rendering input box on new session and history load.
> 
>   - **Behavior**:
>     - Replace `mainTextInputRef.current?.focus?.()` with `setSessionKey(prev => prev + 1)` in `AiderGUI` and `PerplexityGUI` for re-rendering `ContinueInputBox` on new session and history load.
>   - **State Management**:
>     - Add `sessionKey` state in `AiderGUI` and `PerplexityGUI` to manage re-renders.
>     - Update `sessionKey` in `useWebviewListener` for "newSession" and "loadMostRecentChat" events in `PerplexityGUI`.
>   - **Components**:
>     - Pass `sessionKey` as `key` prop to `ContinueInputBox` in `AiderGUI` and `PerplexityGUI`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 90987e297279cc8f75e7f0445fb12f0ead7a9b51. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->