### PR TITLE
focus back to editor when closing overlay

### DIFF
--- a/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
+++ b/extensions/vscode/src/ContinueGUIWebviewViewProvider.ts
@@ -274,6 +274,7 @@ export class ContinueGUIWebviewViewProvider
             document.body.addEventListener('click', function(e) {
                 if (e.target === document.body) {
                     vscode.postMessage({ messageType: 'closeOverlay', messageId: "closeOverlay" });
+                    vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
                 }
             });
           </script>

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -387,6 +387,7 @@ const commandsMap: (
     },
     "pearai.toggleOverlay": async () => {
       await handleIntegrationShortcutKey("toggleOverlay", "inventory", sidebar, [PEAR_OVERLAY_VIEW_ID, PEAR_CONTINUE_VIEW_ID]);
+      vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
     },
     "pearai.toggleInventoryHome": async () => {
       await handleIntegrationShortcutKey("navigateToInventoryHome", "home", sidebar, [PEAR_OVERLAY_VIEW_ID, PEAR_CONTINUE_VIEW_ID]);

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -95,6 +95,7 @@ export class VsCodeMessenger {
     });
     this.onWebview("closeOverlay", (msg) => {
       vscode.commands.executeCommand("pearai.hideOverlay");
+      vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
     });
     this.onWebview("lockOverlay", (msg) => {
       vscode.commands.executeCommand("pearai.lockOverlay");

--- a/extensions/vscode/src/util/integrationUtils.ts
+++ b/extensions/vscode/src/util/integrationUtils.ts
@@ -59,6 +59,7 @@ export async function handleIntegrationShortcutKey(protocol: keyof ToWebviewProt
   if (isOverlayVisible && currentTab === integrationName) {
     // close overlay
     await vscode.commands.executeCommand("pearai.hideOverlay");
+    await vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup");
     return;
   }
   


### PR DESCRIPTION
## Description ✏️

Closes #xxx

What changed? Feel free to be brief.

- Bullet points are helpful.
- Screenshots are helpful (if applicable).

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure editor focus after closing overlays by adding focus command in multiple files.
> 
>   - **Behavior**:
>     - Adds `vscode.commands.executeCommand("workbench.action.focusActiveEditorGroup")` to focus editor after closing overlays in `ContinueGUIWebviewViewProvider.ts`, `commands.ts`, `VsCodeMessenger.ts`, and `integrationUtils.ts`.
>   - **Commands**:
>     - Updates `pearai.toggleOverlay` in `commands.ts` to focus editor after toggling overlay.
>   - **Webview**:
>     - Updates `closeOverlay` and `lockOverlay` handlers in `VsCodeMessenger.ts` to focus editor after closing or locking overlay.
>   - **Utilities**:
>     - Updates `handleIntegrationShortcutKey` in `integrationUtils.ts` to focus editor after hiding overlay.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for fe2fee25f20a1e4144c8d7a79ec7cbd2c660b7ea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->