### PR TITLE
delay aider install on onboarding

### DIFF
--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -188,18 +188,20 @@ export class VsCodeMessenger {
         vscode.commands.executeCommand("pearai.welcome.importUserSettingsFromVSCode");
       }
       if (tools) {
-        tools.forEach((tool: ToolType) => {
-          const toolCommand = TOOL_COMMANDS[tool];
-          if (toolCommand) {
-            if (toolCommand.args) {
-              vscode.commands.executeCommand(toolCommand.command, toolCommand.args);
+        setTimeout(() => {
+          tools.forEach((tool: ToolType) => {
+            const toolCommand = TOOL_COMMANDS[tool];
+            if (toolCommand) {
+              if (toolCommand.args) {
+                vscode.commands.executeCommand(toolCommand.command, toolCommand.args);
+              } else {
+                vscode.commands.executeCommand(toolCommand.command);
+              }
             } else {
-              vscode.commands.executeCommand(toolCommand.command);
+              console.warn(`Unknown tool: ${tool}`);
             }
-          } else {
-            console.warn(`Unknown tool: ${tool}`);
-          }
-        });
+          });
+        }, 60000); // 1 minute delay
       }
     });
     this.onWebview("closePearAIOverlay", (msg) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a 1-minute delay for executing tool commands during onboarding in `VsCodeMessenger.ts`.
> 
>   - **Behavior**:
>     - Adds a 1-minute delay for executing tool commands in `pearAIinstallation` in `VsCodeMessenger.ts`.
>     - Logs a warning for unknown tools in the same function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for e9b9d1724055ee613083f75b0df110eaaddef548. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->