### PR TITLE
ui fixes 2

### DIFF
--- a/core/protocol/webview.ts
+++ b/core/protocol/webview.ts
@@ -9,6 +9,7 @@ export type ToWebviewFromIdeOrCoreProtocol = {
   refreshSubmenuItems: [undefined, void];
   isContinueInputFocused: [undefined, boolean];
   pearAISignedIn: [undefined, void];
+  switchModel: [string, void];
   addContextItem: [
     {
       historyIndex: number;

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -925,6 +925,7 @@ const commandsMap: (
         // limit reached, switching to free model
         vscode.window.showInformationMessage(msg.warningMsg);
         extensionContext.globalState.update("freeModelSwitched", true);
+        sidebar.webviewProtocol?.request("switchModel", "PearAI Model", ["pearai.pearAIChatView"]);
       }
     },
     "pearai.patchWSL": async () => {

--- a/gui/src/components/InventoryPreview.tsx
+++ b/gui/src/components/InventoryPreview.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useContext } from "react";
 import { getLogoPath } from "@/pages/welcome/setup/ImportExtensions";
 import { IdeMessengerContext } from "@/context/IdeMessenger";
@@ -16,22 +16,26 @@ const InventoryPreview = () => {
     {
       icon: "chat-default.svg",
       path: "/inventory/aiderMode",
-      tooltip: "Creator",
+      tooltip: "Inventory",
+      command: "pearai.toggleInventoryHome",
     },
     {
       icon: "creator-default.svg",
       path: "/inventory/aiderMode",
       tooltip: "Creator",
+      command: "pearai.toggleCreator",
     },
     {
       icon: "search-default.svg",
       path: "/inventory/perplexityMode",
       tooltip: "Search",
+      command: "pearai.toggleSearch",
     },
     {
       icon: "memory-default.svg",
       path: "/inventory/mem0Mode",
       tooltip: "Memory",
+      command: "pearai.toggleMem0",
     }
   ];
 
@@ -43,9 +47,7 @@ const InventoryPreview = () => {
     <div className={`mt-2 relative w-full z-10`}>
 
       <div
-        onClick={openInventory}
         className="flex cursor-pointer"
-        title={`Open Inventory (${getMetaKeyLabel()}E)`}
       >
         <div className="flex flex-row items-center">
           <div className="overflow-hidden rounded-[12px] relative">
@@ -60,14 +62,17 @@ const InventoryPreview = () => {
                 <div
                   key={item.path}
                   className="relative group w-6 h-6 rounded-lg"
+                  title={item.tooltip}
                 >
-                  <img
-                    src={getLogoPath(item.icon)}
-                    className="w-6 h-6 rounded-lg"
-                    style={index === 0 ? {
-                      boxShadow: '0px 0px 40px 8px #AFF349'
-                    } : undefined}
-                  />
+                  <a href={`command:${item.command}`}>
+                    <img
+                      src={getLogoPath(item.icon)}
+                      className="w-6 h-6 rounded-lg"
+                      style={index === 0 ? {
+                        boxShadow: '0px 0px 40px 8px #AFF349'
+                      } : undefined}
+                    />
+                  </a>
                   {index === 0 && (
                     <div
                       className="absolute inset-0 pointer-events-none rounded-lg"

--- a/gui/src/components/gui/StepContainer.tsx
+++ b/gui/src/components/gui/StepContainer.tsx
@@ -45,6 +45,8 @@ interface StepContainerProps {
 }
 
 const ContentDiv = styled.div<{ isUserInput: boolean; fontSize?: number }>`
+  padding-left: 10px;
+  padding-right: 10px;
   background-color: ${(props) =>
     props.isUserInput
       ? vscInputBackground
@@ -163,7 +165,7 @@ function StepContainer({
   return (
       <div className="relative pb-[13px]">
         <ContentDiv
-          className="max-w-3xl mx-auto"
+          className="max-w-4xl mx-auto"
           hidden={!open}
           isUserInput={isUserInput}
           fontSize={getFontSize()}

--- a/gui/src/components/gui/StepContainer.tsx
+++ b/gui/src/components/gui/StepContainer.tsx
@@ -28,6 +28,7 @@ import HeaderButtonWithText from "../HeaderButtonWithText";
 import { CopyButton } from "../markdown/CopyButton";
 import StyledMarkdownPreview from "../markdown/StyledMarkdownPreview";
 import { isAiderMode, isBareChatMode, isPerplexityMode } from "../../util/bareChatMode";
+import { getModelImage } from "@/util/aibrandimages";
 
 interface StepContainerProps {
   item: ChatHistoryItem;
@@ -199,7 +200,15 @@ function StepContainer({
           >
             {modelTitle && (
               <div className="flex items-center font-[500]">
-                <CubeIcon className="w-[14px] h-[14px] mr-1 stroke-2" />
+                {getModelImage(modelTitle) !== 'not found' ? (
+                  <img
+                    src={`${window.vscMediaUrl}/logos/${getModelImage(modelTitle)}`}
+                    className="w-3.5 h-3.5 mr-2 object-contain rounded-sm"
+                    alt={modelTitle}  
+                  />
+                ) : (
+                  <CubeIcon className="w-[14px] h-[14px] mr-1 stroke-2" />
+                )}
                 {modelTitle}
               </div>
             )}

--- a/gui/src/inventory/pages/InventoryPage.tsx
+++ b/gui/src/inventory/pages/InventoryPage.tsx
@@ -17,6 +17,7 @@ import { getLogoPath } from "@/pages/welcome/setup/ImportExtensions";
 import { IdeMessengerContext } from "@/context/IdeMessenger";
 import { RootState } from "@/redux/store";
 import { useSelector } from "react-redux";
+import { DEVELOPER_WRAPPED_FEATURE_FLAG } from "@/util/featureflags";
 
 enum AIToolID {
   SEARCH = "search",
@@ -31,6 +32,7 @@ enum AIToolID {
 interface AITool {
   id: string;
   name: string;
+  featureFlag?: boolean;
   description: ReactElement;
   icon: string;
   whenToUse: ReactElement;
@@ -366,6 +368,7 @@ export default function AIToolInventory() {
     {
       id: AIToolID.WRAPPED,
       name: "Developer Wrapped",
+      featureFlag: DEVELOPER_WRAPPED_FEATURE_FLAG,
       description: (
         <span>View your year in code - only in PearAI! 🎉</span>
       ),
@@ -417,7 +420,8 @@ export default function AIToolInventory() {
   // ]);
 
   const filteredTools = tools.filter((tool) =>
-    tool.name.toLowerCase().includes(searchQuery.toLowerCase()),
+    tool.name.toLowerCase().includes(searchQuery.toLowerCase()) &&
+    (tool.featureFlag !== false)
   );
 
   const handleToggle = (id: string) => {

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -445,7 +445,7 @@ function GUI() {
       </TopGuiDiv>
 
       {(
-        <div className="flex flex-col gap-0.5 px-2">
+        <div className="flex flex-col gap-0.5 px-2 rounded-t-lg">
           <ContinueInputBox
             onEnter={(editorContent, modifiers) => {
               sendInput(editorContent, modifiers);

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -466,7 +466,7 @@ function GUI() {
         })}
       </TopGuiDiv>
 
-      {(
+      {!active && (
         <div className="flex flex-col gap-0.5 px-2 rounded-t-lg">
           <ContinueInputBox
             onEnter={(editorContent, modifiers) => {

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -344,7 +344,7 @@ function GUI() {
       <TopGuiDiv ref={topGuiDivRef} onScroll={handleScroll} isNewSession={isNewSession}>
         {state.history.map((item, index: number) => {
           // Insert warning card after the 30th message
-          const showWarningHere = index === 3;
+          const showWarningHere = index === 29;
 
           return (
             <Fragment key={index}>

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -42,6 +42,7 @@ import {
   clearLastResponse,
   deleteMessage,
   newSession,
+  setDefaultModel,
   setInactive,
   setShowInteractiveContinueTutorial,
 } from "../redux/slices/stateSlice";
@@ -309,6 +310,10 @@ function GUI() {
     },
     [],
   );
+
+  useWebviewListener("switchModel", async (model: string) => {
+    dispatch(setDefaultModel({ title: model }));
+  });
 
   const isLastUserInput = useCallback(
     (index: number): boolean => {

--- a/gui/src/util/aibrandimages.ts
+++ b/gui/src/util/aibrandimages.ts
@@ -1,0 +1,23 @@
+export function getModelImage(modelTitle: string) {
+  const modelTitleLower = modelTitle.toLowerCase();
+  switch (true) {
+    case modelTitleLower.includes('pearai'):
+      return 'pearai-color.png';
+    case modelTitleLower.includes('claude'):
+      return 'anthropic.png';
+    case modelTitleLower.includes('gpt'):
+      return 'openai.png';
+    case modelTitleLower.includes('deepseek'):
+      return 'deepseek-svg.svg';
+    case modelTitleLower.includes('gemini'):
+      return 'gemini-icon.png';
+    case modelTitleLower.includes('llama'):
+      return 'llama.png';
+    case modelTitleLower.includes("mistral"):
+      return 'mistral.png';
+    case modelTitleLower.includes('perplexity'):
+      return 'perplexity.png';
+    default:
+      return 'not found';
+  }
+}


### PR DESCRIPTION
- **inv preview btns open respective tool**
- **staggered look for chat box**
- **show warning on 29th**
- **model icon on responses**
- **switch to pearai model when credits exhausted**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance PearAI UI with model switching, chat box updates, and model icons in responses.
> 
>   - **Behavior**:
>     - Add `switchModel` protocol in `webview.ts` to switch to PearAI model when credits are exhausted.
>     - Show warning after 29th message in chat in `gui.tsx`.
>   - **UI Enhancements**:
>     - Add model icons in chat responses using `getModelImage()` in `StepContainer.tsx`.
>     - Update `InventoryPreview.tsx` to use command links for inventory buttons.
>     - Adjust chat box layout for a staggered look in `StepContainer.tsx`.
>   - **Misc**:
>     - Add `getModelImage()` function in `aibrandimages.ts` to map model titles to icons.
>     - Add feature flag for Developer Wrapped in `InventoryPage.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for cad9808b1d0653dbedd3c1438e658d13073ca938. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->