### PR TITLE
Wait for VSCode Settings Import to finish before proceeding to next step

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 extensions/vscode/continue_rc_schema.json
 **/.pearaiignore
 CHANGELOG.md
-# *.tsx # temporary for local dev, do not merge with this
-# *.ts # temporary for local dev, do not merge with this
+
+# temporary for local dev, do not merge with this
+*.tsx
+*.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 extensions/vscode/continue_rc_schema.json
 **/.pearaiignore
 CHANGELOG.md
+# *.tsx
+*.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,3 @@
 extensions/vscode/continue_rc_schema.json
 **/.pearaiignore
 CHANGELOG.md
-
-# temporary for local dev, do not merge with this
-*.tsx
-*.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 extensions/vscode/continue_rc_schema.json
 **/.pearaiignore
 CHANGELOG.md
-# *.tsx
-*.ts
+# *.tsx # temporary for local dev, do not merge with this
+# *.ts # temporary for local dev, do not merge with this

--- a/core/protocol/ide.ts
+++ b/core/protocol/ide.ts
@@ -7,11 +7,11 @@ import type {
   IdeSettings,
   IndexTag,
   Location,
+  PearAuth,
   Problem,
   Range,
   RangeInFile,
   Thread,
-  PearAuth,
 } from "../index.js";
 
 export type ToIdeFromWebviewOrCoreProtocol = {
@@ -91,7 +91,7 @@ export type ToIdeFromWebviewOrCoreProtocol = {
 
   // new welcome page
   markNewOnboardingComplete: [undefined, void];
-  importUserSettingsFromVSCode: [undefined, void];
+  importUserSettingsFromVSCode: [undefined, boolean];
   pearWelcomeOpenFolder: [undefined, void];
   pearInstallCommandLine: [undefined, void];
   installVscodeExtension: [{ extensionId: string }, void];

--- a/core/protocol/ideWebview.ts
+++ b/core/protocol/ideWebview.ts
@@ -1,5 +1,9 @@
 import { AiderState } from "../../extensions/vscode/src/integrations/aider/types/aiderTypes.js";
-import { ToolType, Memory, MemoryChange } from "../../extensions/vscode/src/util/integrationUtils.js";
+import {
+  Memory,
+  MemoryChange,
+  ToolType,
+} from "../../extensions/vscode/src/util/integrationUtils.js";
 import type { RangeInFileWithContents } from "../commands/util.js";
 import type { ContextSubmenuItem } from "../index.js";
 import { ToIdeFromWebviewOrCoreProtocol } from "./ide.js";
@@ -19,17 +23,17 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
   openUrl: [string, void];
   applyToCurrentFile: [{ text: string }, void];
   applyWithRelaceHorizontal: [{ contentToApply: string }, void];
-  acceptRelaceDiff: [{ originalFileUri: string, diffFileUri: string }, void];
-  rejectRelaceDiff: [{ originalFileUri: string, diffFileUri: string }, void];
-  createFile: [{ path: string}, void];
+  acceptRelaceDiff: [{ originalFileUri: string; diffFileUri: string }, void];
+  rejectRelaceDiff: [{ originalFileUri: string; diffFileUri: string }, void];
+  createFile: [{ path: string }, void];
   showTutorial: [undefined, void];
   showFile: [{ filepath: string }, void];
   openConfigJson: [undefined, void];
-  highlightElement: [{elementSelectors: string[]}, void];
-  unhighlightElement: [{elementSelectors: string[]}, void];
+  highlightElement: [{ elementSelectors: string[] }, void];
+  unhighlightElement: [{ elementSelectors: string[] }, void];
   perplexityMode: [undefined, void];
-  addPerplexityContext: [{text: string, language: string}, void]
-  addPerplexityContextinChat: [{ text: string, language: string }, void];
+  addPerplexityContext: [{ text: string; language: string }, void];
+  addPerplexityContextinChat: [{ text: string; language: string }, void];
   aiderMode: [undefined, void];
   aiderCtrlC: [undefined, void];
   sendAiderProcessStateToGUI: [undefined, void];
@@ -60,7 +64,8 @@ export type ToIdeFromWebviewProtocol = ToIdeFromWebviewOrCoreProtocol & {
   completeWelcome: [undefined, void];
   openInventoryHome: [undefined, void];
   getUrlTitle: [string, string];
-  pearAIinstallation: [{tools: ToolType[], installExtensions: boolean}, void];
+  pearAIinstallation: [{ tools: ToolType[] }, void];
+  importUserSettingsFromVSCode: [undefined, boolean];
   "mem0/getMemories": [undefined, Memory[]];
   "mem0/updateMemories": [{ changes: MemoryChange[] }, boolean];
 };
@@ -93,7 +98,7 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   viewHistory: [undefined, void];
   newSession: [undefined, void];
   quickEdit: [undefined, void];
-  acceptedOrRejectedDiff: [undefined, void]
+  acceptedOrRejectedDiff: [undefined, void];
   setTheme: [{ theme: any }, void];
   setThemeType: [{ themeType: string }, void];
   setColors: [{ [key: string]: string }, void];
@@ -102,8 +107,8 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   setupLocalModel: [undefined, void];
   incrementFtc: [undefined, void];
   openOnboarding: [undefined, void];
-  addPerplexityContext: [{text: string, language: string}, void]
-  addPerplexityContextinChat: [{ text: string, language: string }, void];
+  addPerplexityContext: [{ text: string; language: string }, void];
+  addPerplexityContextinChat: [{ text: string; language: string }, void];
   navigateToCreator: [undefined, void];
   navigateToSearch: [undefined, void];
   navigateToMem0: [undefined, void];
@@ -112,5 +117,5 @@ export type ToWebviewFromIdeProtocol = ToWebviewFromIdeOrCoreProtocol & {
   navigateToInventoryHome: [undefined, void];
   getCurrentTab: [undefined, string];
   setAiderProcessStateInGUI: [AiderState, void];
-  setRelaceDiffState: [{diffVisible: boolean}, void];
+  setRelaceDiffState: [{ diffVisible: boolean }, void];
 };

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -183,6 +183,12 @@
         "group": "PearAI"
       },
       {
+        "command": "pearai.startOnboarding",
+        "category": "PearAI Developer",
+        "title": "Start PearAI Onboarding",
+        "group": "PearAI"
+      },
+      {
         "command": "pearai.developer.restFirstLaunch",
         "category": "PearAI Developer",
         "title": "Reset PearAI Onboarding",

--- a/extensions/vscode/src/commands.ts
+++ b/extensions/vscode/src/commands.ts
@@ -22,20 +22,17 @@ import {
   quickPickStatusText,
   setupStatusBar,
 } from "./autocomplete/statusBar";
-import { ContinueGUIWebviewViewProvider, PEAR_OVERLAY_VIEW_ID } from "./ContinueGUIWebviewViewProvider";
+import { ContinueGUIWebviewViewProvider, PEAR_CONTINUE_VIEW_ID, PEAR_OVERLAY_VIEW_ID } from "./ContinueGUIWebviewViewProvider";
+import { FIRST_LAUNCH_KEY, importUserSettingsFromVSCode, isFirstLaunch } from "./copySettings";
 import { DiffManager } from "./diff/horizontal";
 import { VerticalPerLineDiffManager } from "./diff/verticalPerLine/manager";
+import { aiderCtrlC, aiderResetSession, installAider, sendAiderProcessStateToGUI, uninstallAider } from './integrations/aider/aiderUtil';
+import { AiderState } from "./integrations/aider/types/aiderTypes";
 import { QuickEdit, QuickEditShowParams } from "./quickEdit/QuickEditQuickPick";
 import { Battery } from "./util/battery";
-import type { VsCodeWebviewProtocol } from "./webviewProtocol";
-import { getExtensionUri } from "./util/vscode";
-import { aiderCtrlC, aiderResetSession, openAiderPanel, sendAiderProcessStateToGUI, installAider, uninstallAider } from './integrations/aider/aiderUtil';
-import { handlePerplexityMode } from "./integrations/perplexity/perplexity";
-import { PEAR_CONTINUE_VIEW_ID } from "./ContinueGUIWebviewViewProvider";
 import { handleIntegrationShortcutKey } from "./util/integrationUtils";
-import { FIRST_LAUNCH_KEY, importUserSettingsFromVSCode, isFirstLaunch } from "./copySettings";
-import { attemptInstallExtension } from "./activation/activate";
-import { AiderState } from "./integrations/aider/types/aiderTypes";
+import { getExtensionUri } from "./util/vscode";
+import type { VsCodeWebviewProtocol } from "./webviewProtocol";
 
 
 let fullScreenPanel: vscode.WebviewPanel | undefined;
@@ -260,9 +257,9 @@ const commandsMap: (
       if (!isFirstLaunch(extensionContext)) {
         vscode.window.showInformationMessage("Welcome back! User settings import is skipped as this is not the first launch.");
         console.dir("Extension launch detected as a subsequent launch. Skipping user settings import.");
-        return;
+        return true;
       }
-      await importUserSettingsFromVSCode();
+      return await importUserSettingsFromVSCode();
     },
     "pearai.welcome.markNewOnboardingComplete": async () => {
       await extensionContext.globalState.update(FIRST_LAUNCH_KEY, true);

--- a/extensions/vscode/src/copySettings.ts
+++ b/extensions/vscode/src/copySettings.ts
@@ -142,7 +142,6 @@ export async function importUserSettingsFromVSCode() {
           new Promise((resolve) => setTimeout(resolve, 1000)), // Take at least one second
           copyVSCodeSettingsToPearAIDir(),
         ]);
-        // throw new Error("Test error message");
         return true;
       } catch (error) {
         vscode.window.showErrorMessage(`Failed to copy settings: ${error}`);

--- a/extensions/vscode/src/copySettings.ts
+++ b/extensions/vscode/src/copySettings.ts
@@ -1,7 +1,7 @@
-import * as vscode from "vscode";
 import * as fs from 'fs';
-import * as path from 'path';
 import * as os from 'os';
+import * as path from 'path';
+import * as vscode from "vscode";
 
 export const FIRST_LAUNCH_KEY = 'pearai.firstLaunch';
 const pearAISettingsDir = path.join(os.homedir(), '.pearai');
@@ -46,11 +46,11 @@ async function copyVSCodeSettingsToPearAIDir() {
     await fs.promises.mkdir(pearAIDevExtensionsDir, { recursive: true });
 
     const itemsToCopy = ['settings.json', 'keybindings.json', 'snippets', 'sync', 'globalStorage/state.vscdb', 'globalStorage/state.vscdb.backup'];
-    
+
     for (const item of itemsToCopy) {
         const source = path.join(vscodeSettingsDir, item);
         const destination = path.join(pearAIDevSettingsDir, item);
-        
+
         try {
             if (await fs.promises.access(source).then(() => true).catch(() => false)) {
                 const stats = await fs.promises.lstat(source);
@@ -67,7 +67,7 @@ async function copyVSCodeSettingsToPearAIDir() {
 
     const baseExclusions = new Set([
         'pearai.pearai',
-        'ms-python.vscode-pylance', 
+        'ms-python.vscode-pylance',
         'ms-python.python',
         'codeium',
         'github.copilot',
@@ -81,7 +81,7 @@ async function copyVSCodeSettingsToPearAIDir() {
         baseExclusions.add('ms-vscode-remote.remote-ssh');
         baseExclusions.add('ms-vscode-remote.remote-ssh-edit');
     }
-    
+
     // Add platform specific exclusions
     if (process.platform === 'darwin' && process.arch === 'x64') {
         baseExclusions.add('ms-python.vscode-pylance');
@@ -96,7 +96,7 @@ async function copyVSCodeSettingsToPearAIDir() {
     // Add Linux specific exclusions
     // if (process.platform === 'linux') {
     // }
-    
+
     await copyDirectoryRecursiveSync(vscodeExtensionsDir, pearAIDevExtensionsDir, Array.from(baseExclusions));
 }
 
@@ -113,7 +113,7 @@ function getVSCodeSettingsDir() {
 
 async function copyDirectoryRecursiveSync(source: string, destination: string, exclusions: string[] = []) {
     await fs.promises.mkdir(destination, { recursive: true });
-    
+
     const items = await fs.promises.readdir(source);
     for (const item of items) {
         const sourcePath = path.join(source, item);
@@ -121,7 +121,7 @@ async function copyDirectoryRecursiveSync(source: string, destination: string, e
 
         const shouldExclude = exclusions.some(exclusion =>
             sourcePath.toLowerCase().includes(exclusion.toLowerCase())
-            
+
         );
 
         if (!shouldExclude) {
@@ -138,27 +138,25 @@ async function copyDirectoryRecursiveSync(source: string, destination: string, e
 
 export async function importUserSettingsFromVSCode() {
     try {
-        await new Promise(resolve => setTimeout(resolve, 3000));
-        
-        vscode.window.showInformationMessage('Copying your current VSCode settings and extensions over to PearAI!');
-        await copyVSCodeSettingsToPearAIDir();
-        
-        vscode.window.showInformationMessage(
-            'Your VSCode settings and extensions have been transferred over to PearAI! You may need to restart your editor for the changes to take effect.',
-            'Ok'
-        );
-    } catch (error) {
+        await Promise.all([
+          new Promise((resolve) => setTimeout(resolve, 1000)), // Take at least one second
+          copyVSCodeSettingsToPearAIDir(),
+        ]);
+        // throw new Error("Test error message");
+        return true;
+      } catch (error) {
         vscode.window.showErrorMessage(`Failed to copy settings: ${error}`);
+        return false;
+      }
     }
-}
 
 export async function markCreatorOnboardingCompleteFileBased() {
     try {
         await new Promise(resolve => setTimeout(resolve, 3000));
-        
+
         const flagFile = firstPearAICreatorLaunchFlag;
         const productName = 'PearAI Creator';
-        
+
         const exists = await fs.promises.access(flagFile).then(() => true).catch(() => false);
         if (!exists) {
             await fs.promises.writeFile(flagFile, `This is the first launch flag file for ${productName}`);

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -106,16 +106,9 @@ export class VsCodeMessenger {
     });
     this.onWebview("importUserSettingsFromVSCode", async (msg) => {
       try {
-        const val = await vscode.commands.executeCommand(
+        return await vscode.commands.executeCommand(
           "pearai.welcome.importUserSettingsFromVSCode",
         );
-        console.log(
-          "importUserSettingsFromVSCode result:",
-          val,
-          "Type:",
-          typeof val,
-        );
-        return typeof val === "boolean" ? val : false;
       } catch (error) {
         console.log("importUserSettingsFromVSCode rejectionReason", error);
         return false;

--- a/extensions/vscode/src/extension/VsCodeMessenger.ts
+++ b/extensions/vscode/src/extension/VsCodeMessenger.ts
@@ -1,6 +1,7 @@
 // Note: This file has been modified significantly from its original contents. New commands have been added, and there has been renaming from Continue to PearAI. pearai-submodule is a fork of Continue (https://github.com/continuedev/continue).
 
 import { ConfigHandler } from "core/config/ConfigHandler";
+import PearAIServer from "core/llm/llms/PearAIServer";
 import {
   FromCoreProtocol,
   FromWebviewProtocol,
@@ -18,22 +19,19 @@ import { getConfigJsonPath } from "core/util/paths";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as vscode from "vscode";
+import { attemptInstallExtension, attemptUninstallExtension, isVSCodeExtensionInstalled } from "../activation/activate";
 import { VerticalPerLineDiffManager } from "../diff/verticalPerLine/manager";
 import { VsCodeIde } from "../ideProtocol";
+import { checkAiderInstallation } from "../integrations/aider/aiderUtil";
+import { getMem0Memories, updateMem0Memories } from "../integrations/mem0/mem0Service";
+import { getFastApplyChangesWithRelace } from "../integrations/relace/relace";
 import {
   getControlPlaneSessionInfo,
   WorkOsAuthProvider,
 } from "../stubs/WorkOsAuthProvider";
+import { extractCodeFromMarkdown, TOOL_COMMANDS, ToolType } from "../util/integrationUtils";
 import { getExtensionUri } from "../util/vscode";
 import { VsCodeWebviewProtocol } from "../webviewProtocol";
-import { attemptInstallExtension, attemptUninstallExtension, isVSCodeExtensionInstalled } from "../activation/activate";
-import { checkAiderInstallation } from "../integrations/aider/aiderUtil";
-import { getMem0Memories, updateMem0Memories } from "../integrations/mem0/mem0Service";
-import { TOOL_COMMANDS, ToolType, extractCodeFromMarkdown } from "../util/integrationUtils";
-import PearAIServer from "core/llm/llms/PearAIServer";
-import { getFastApplyChangesWithRelace } from "../integrations/relace/relace";
-import { RelaceDiffManager } from "../integrations/relace/relaceDiffManager";
-import { getMarkdownLanguageTagForFile } from "core/util";
 
 /**
  * A shared messenger class between Core and Webview
@@ -106,8 +104,22 @@ export class VsCodeMessenger {
     this.onWebview("unlockOverlay", (msg) => {
       vscode.commands.executeCommand("pearai.unlockOverlay");
     });
-    this.onWebview("importUserSettingsFromVSCode", (msg) => {
-      vscode.commands.executeCommand("pearai.welcome.importUserSettingsFromVSCode");
+    this.onWebview("importUserSettingsFromVSCode", async (msg) => {
+      try {
+        const val = await vscode.commands.executeCommand(
+          "pearai.welcome.importUserSettingsFromVSCode",
+        );
+        console.log(
+          "importUserSettingsFromVSCode result:",
+          val,
+          "Type:",
+          typeof val,
+        );
+        return typeof val === "boolean" ? val : false;
+      } catch (error) {
+        console.log("importUserSettingsFromVSCode rejectionReason", error);
+        return false;
+      }
     });
     this.onWebview("installVscodeExtension", (msg) => {
       attemptInstallExtension(msg.data.extensionId);
@@ -131,7 +143,7 @@ export class VsCodeMessenger {
 
       const memories = await getMem0Memories(PearAIServer._getRepoId());
       return memories;
-    }); 
+    });
     this.onWebview("mem0/updateMemories", async (msg) => {
       const response = await updateMem0Memories(PearAIServer._getRepoId(), msg.data.changes);
       return response;
@@ -183,10 +195,7 @@ export class VsCodeMessenger {
       vscode.commands.executeCommand("pearai.toggleInventoryHome");
     });
     this.onWebview("pearAIinstallation", (msg) => {
-      const { tools, installExtensions } = msg.data;
-      if (installExtensions) {
-        vscode.commands.executeCommand("pearai.welcome.importUserSettingsFromVSCode");
-      }
+      const { tools } = msg.data;
       if (tools) {
         tools.forEach((tool: ToolType) => {
           const toolCommand = TOOL_COMMANDS[tool];

--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -298,7 +298,6 @@ function GUI() {
   useWebviewListener("restFirstLaunchInGUI", async () => {
     setLocalStorage("showTutorialCard", true);
     localStorage.removeItem("onboardingSelectedTools");
-    localStorage.removeItem("importUserSettingsFromVSCode");
     dispatch(setShowInteractiveContinueTutorial(true));
   });
 

--- a/gui/src/pages/welcome/FinalStep.tsx
+++ b/gui/src/pages/welcome/FinalStep.tsx
@@ -1,19 +1,16 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { useContext, useEffect } from "react";
 import { IdeMessengerContext } from "@/context/IdeMessenger";
 import { FolderOpen } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { useContext, useEffect } from "react";
 
 export default function FinalStep({ onNext }: { onNext: () => void }) {
 
-  const navigate = useNavigate();
   const selectedTools = JSON.parse(localStorage.getItem('onboardingSelectedTools'));
-  const installExtensions = localStorage.getItem('importUserSettingsFromVSCode') === 'true';
 
   const initiateInstallations = () => {
-    ideMessenger.post("pearAIinstallation", {tools: selectedTools, installExtensions: installExtensions})
+    ideMessenger.post("pearAIinstallation", {tools: selectedTools});
     ideMessenger.post("markNewOnboardingComplete", undefined);
   };
 

--- a/gui/src/pages/welcome/setup/ImportExtensions.tsx
+++ b/gui/src/pages/welcome/setup/ImportExtensions.tsx
@@ -1,45 +1,66 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { ArrowLongRightIcon } from "@heroicons/react/24/outline";
-import { useContext, useState, useEffect } from "react";
 import { IdeMessengerContext } from "@/context/IdeMessenger";
+import { ArrowLongRightIcon } from "@heroicons/react/24/outline";
+import { useContext, useEffect, useState } from "react";
 
 export const getLogoPath = (assetName: string) => {
   return `${window.vscMediaUrl}/logos/${assetName}`;
 };
 
-export default function ImportExtensions({
-  onNext,
-}: {
-  onNext: () => void;
-}) {
+export default function ImportExtensions({ onNext }: { onNext: () => void }) {
   const [isImporting, setIsImporting] = useState(false);
+  const [isDone, setIsDone] = useState(false);
+  const [importError, setImportError] = useState("");
+  const ideMessenger = useContext(IdeMessengerContext);
 
-  const handleImport = () => {
-    localStorage.setItem('importUserSettingsFromVSCode', 'true');
+  const handleImport = async () => {
+    localStorage.setItem("importUserSettingsFromVSCode", "true");
     setIsImporting(true);
-    onNext();
+    setImportError("");
+    const settingsLoaded = await ideMessenger.request(
+      "importUserSettingsFromVSCode",
+      undefined,
+    );
+    if (typeof settingsLoaded === "boolean" && settingsLoaded) {
+      setIsDone(true);
+      onNext();
+    } else {
+      console.dir("settings not loaded");
+      setIsImporting(false);
+      localStorage.setItem("importUserSettingsFromVSCode", "false");
+      setIsDone(false); // being verbose on purpose
+      setImportError(
+        "Something went wrong while importing your settings. Please skip or try again.",
+      );
+    }
   };
 
   const handleSkip = () => {
-    localStorage.setItem('importUserSettingsFromVSCode', 'false');
-    onNext()
-  }
+    localStorage.setItem("importUserSettingsFromVSCode", "false");
+    onNext();
+  };
 
   useEffect(() => {
-    setIsImporting(localStorage.getItem('importUserSettingsFromVSCode') === 'true')
+    setIsImporting(
+      localStorage.getItem("importUserSettingsFromVSCode") === "true",
+    );
     const handleKeyPress = (event: KeyboardEvent) => {
-      if (event.key === 'Enter' && !isImporting) {
+      if (event.key === "Enter" && !isImporting) {
         handleImport();
-      } else if ((event.metaKey || event.ctrlKey) && event.key === 'ArrowRight' && !isImporting) {
+      } else if (
+        (event.metaKey || event.ctrlKey) &&
+        event.key === "ArrowRight" &&
+        !isImporting
+      ) {
         event.preventDefault();
         onNext();
       }
     };
 
-    window.addEventListener('keydown', handleKeyPress);
-    return () => window.removeEventListener('keydown', handleKeyPress);
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
   }, [isImporting]); // Include isImporting in dependencies to prevent import when already in progress
 
   return (
@@ -50,61 +71,79 @@ export default function ImportExtensions({
             Import your extensions <br /> and user settings from VSCode
           </h2>
           <div className="flex items-center justify-center gap-8 mb-8">
-            <img src={getLogoPath("vscode.svg")} className="w-[100px] h-[100px]" alt="VS Code" />
+            <img
+              src={getLogoPath("vscode.svg")}
+              className="w-[100px] h-[100px]"
+              alt="VS Code"
+            />
             <ArrowLongRightIcon className="w-8 h-8 text-muted-foreground" />
-            <img src={getLogoPath("pearai-green.svg")} className="w-36 h-36 ml-[-2.5rem]" alt="PearAI" />
+            <img
+              src={getLogoPath("pearai-green.svg")}
+              className="w-36 h-36 ml-[-2.5rem]"
+              alt="PearAI"
+            />
           </div>
 
-            {!isImporting ? 
-          <div className="absolute bottom-8 right-8 flex items-center gap-4">
-              <div onClick={handleSkip} className="flex items-center gap-2 cursor-pointer">
-                <span className="text-center w-full">Skip</span>
-              </div>
-              <Button
-              disabled={isImporting}
-              className="w-[250px] text-button-foreground bg-button hover:bg-button-hover p-4 lg:py-6 lg:px-2 text-sm md:text-base cursor-pointer transition-all duration-300"
-              onClick={handleImport}
-            >
-              <div className="flex items-center justify-between w-full gap-2">
-                {isImporting ? (
-                  <div className="flex items-center justify-center w-full gap-2">
-                    <svg
-                      className="animate-spin h-5 w-5 text-button-foreground"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                    >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      />
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      />
-                    </svg>
-                    <span>Importing...</span>
+          {!isDone ? (
+            <div>
+              {importError ? <p>{importError}</p> : null}
+              <div className="absolute bottom-8 right-8 flex items-center gap-4">
+                {/* TODO: hide skip button for the first five seconds or something and then show */}
+                <div
+                  onClick={handleSkip}
+                  className="flex items-center gap-2 cursor-pointer"
+                >
+                  <span className="text-center w-full">Skip</span>
+                </div>
+                <Button
+                  disabled={isImporting}
+                  className="w-[250px] text-button-foreground bg-button hover:bg-button-hover p-4 lg:py-6 lg:px-2 text-sm md:text-base cursor-pointer transition-all duration-300"
+                  onClick={handleImport}
+                >
+                  <div className="flex items-center justify-between w-full gap-2">
+                    {isImporting ? (
+                      <div className="flex items-center justify-center w-full gap-2">
+                        <svg
+                          className="animate-spin h-5 w-5 text-button-foreground"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                        >
+                          <circle
+                            className="opacity-25"
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="4"
+                          />
+                          <path
+                            className="opacity-75"
+                            fill="currentColor"
+                            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                          />
+                        </svg>
+                        <span>Importing...</span>
+                      </div>
+                    ) : (
+                      <>
+                        <span className="text-center w-full">Import</span>
+                      </>
+                    )}
                   </div>
-                ) : (
-                  <>
-                    <span className="text-center w-full">Import</span>
-                  </>
-                )}
+                </Button>
               </div>
-            </Button> 
             </div>
-            : 
+          ) : (
             <div className="flex flex-col items-center gap-4 mb-24">
-              <div>Import in progress! You can leave this page</div>
-              <div onClick={onNext} className="flex items-center gap-2 cursor-pointer">
-                  <span className="text-center w-full">Continue</span>
+              <div>Done importing! You can leave this page</div>
+              <div
+                onClick={onNext}
+                className="flex items-center gap-2 cursor-pointer"
+              >
+                <span className="text-center w-full">Continue</span>
               </div>
             </div>
-          }
+          )}
         </div>
       </div>
     </div>

--- a/gui/src/pages/welcome/setup/ImportExtensions.tsx
+++ b/gui/src/pages/welcome/setup/ImportExtensions.tsx
@@ -86,7 +86,6 @@ export default function ImportExtensions({ onNext }: { onNext: () => void }) {
             <div>
               {importError ? <p>{importError}</p> : null}
               <div className="absolute bottom-8 right-8 flex items-center gap-4">
-                {/* TODO: hide skip button for the first five seconds or something and then show */}
                 {showSkip && (
                   <div onClick={handleSkip} className="flex items-center gap-2 cursor-pointer">
                     <span className="text-center w-full">Skip</span>

--- a/gui/src/pages/welcome/setup/ImportExtensions.tsx
+++ b/gui/src/pages/welcome/setup/ImportExtensions.tsx
@@ -59,8 +59,8 @@ export default function ImportExtensions({ onNext }: { onNext: () => void }) {
       }
     };
 
-    window.addEventListener("keydown", handleKeyPress);
-    return () => window.removeEventListener("keydown", handleKeyPress);
+    window.addEventListener('keydown', handleKeyPress);
+    return () => window.removeEventListener('keydown', handleKeyPress);
   }, [isImporting]); // Include isImporting in dependencies to prevent import when already in progress
 
   return (
@@ -71,17 +71,9 @@ export default function ImportExtensions({ onNext }: { onNext: () => void }) {
             Import your extensions <br /> and user settings from VSCode
           </h2>
           <div className="flex items-center justify-center gap-8 mb-8">
-            <img
-              src={getLogoPath("vscode.svg")}
-              className="w-[100px] h-[100px]"
-              alt="VS Code"
-            />
-            <ArrowLongRightIcon className="w-8 h-8 text-muted-foreground" />
-            <img
-              src={getLogoPath("pearai-green.svg")}
-              className="w-36 h-36 ml-[-2.5rem]"
-              alt="PearAI"
-            />
+            <img src={getLogoPath("vscode.svg")} className="w-[100px] h-[100px]" alt="VS Code" />
+              <ArrowLongRightIcon className="w-8 h-8 text-muted-foreground" />
+            <img src={getLogoPath("pearai-green.svg")} className="w-36 h-36 ml-[-2.5rem]" alt="PearAI" />
           </div>
 
           {!isDone ? (
@@ -89,10 +81,7 @@ export default function ImportExtensions({ onNext }: { onNext: () => void }) {
               {importError ? <p>{importError}</p> : null}
               <div className="absolute bottom-8 right-8 flex items-center gap-4">
                 {/* TODO: hide skip button for the first five seconds or something and then show */}
-                <div
-                  onClick={handleSkip}
-                  className="flex items-center gap-2 cursor-pointer"
-                >
+                <div onClick={handleSkip} className="flex items-center gap-2 cursor-pointer">
                   <span className="text-center w-full">Skip</span>
                 </div>
                 <Button
@@ -136,9 +125,7 @@ export default function ImportExtensions({ onNext }: { onNext: () => void }) {
           ) : (
             <div className="flex flex-col items-center gap-4 mb-24">
               <div>Done importing! You can leave this page</div>
-              <div
-                onClick={onNext}
-                className="flex items-center gap-2 cursor-pointer"
+              <div onClick={onNext} className="flex items-center gap-2 cursor-pointer"
               >
                 <span className="text-center w-full">Continue</span>
               </div>

--- a/gui/src/pages/welcome/setup/ImportExtensions.tsx
+++ b/gui/src/pages/welcome/setup/ImportExtensions.tsx
@@ -43,17 +43,11 @@ export default function ImportExtensions({ onNext }: { onNext: () => void }) {
   };
 
   useEffect(() => {
-    setIsImporting(
-      localStorage.getItem("importUserSettingsFromVSCode") === "true",
-    );
+    setIsImporting(localStorage.getItem("importUserSettingsFromVSCode") === "true");
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "Enter" && !isImporting) {
         handleImport();
-      } else if (
-        (event.metaKey || event.ctrlKey) &&
-        event.key === "ArrowRight" &&
-        !isImporting
-      ) {
+      } else if ((event.metaKey || event.ctrlKey) && event.key === "ArrowRight" && !isImporting) {
         event.preventDefault();
         onNext();
       }

--- a/gui/src/util/localStorage.ts
+++ b/gui/src/util/localStorage.ts
@@ -19,6 +19,7 @@ type LocalStorageTypes = {
   showAiderTutorialCard: boolean;
   shownProfilesIntroduction: boolean;
   disableIndexing: boolean;
+  isDoneImportingUserSettingsFromVSCode: boolean;
 };
 
 export function getLocalStorage<T extends keyof LocalStorageTypes>(


### PR DESCRIPTION
## Description ✏️

Closes https://github.com/trypear/pearai-app/issues/170

- Make the loading for import VSCode Extensions step synchronous
- Show skip button, then hide for 5 seconds, then show again
- Remove associated usages of local storage
- Add error handling
- Still works if you press back 

|  Error Case | Skip Reappears | 
| --- | --- |
| ![error case](https://github.com/user-attachments/assets/ac65443d-6595-402d-b8e7-d883d8fcfdea) | ![skip reappears](https://github.com/user-attachments/assets/b4ba7ac9-d4ed-45eb-87c5-13a6835c208b) |

Initially, I got some permissions error when copying. 

```
Failed to copy settings: Error: EACCES: permission denied, copyfile '/Users/len/.vscode/extensions/redhat.java-1.39.0-darwin-x64/jre/21.0.5-macosx-x86_64/legal/java.base/ADDITIONAL_LICENSE_INFO' -> '/Users/len/.pearai/extensions/redhat.java-1.39.0-darwin-x64/jre/21.0.5-macosx-x86_64/legal/java.base/ADDITIONAL_LICENSE_INFO
```

Then I ran these commands to get it working.

```shell
chmod -R u+rw ~/.vscode/extensions/redhat.java-1.39.0-darwin-x64
chmod -R u+rw ~/.pearai/extensions/
```

| Success Case | It Remembers If You Press Back |
| --- | --- |
| ![success](https://github.com/user-attachments/assets/f5d4228a-5a19-4e3a-a69a-980a72a0411c) | ![remember](https://github.com/user-attachments/assets/97d122ed-c9df-47ce-896d-59d2ddd70855)|

Here we see that it automatically goes to the next step on success, and that if you were to go back for some reason, the "done" status stays there.

## Testing Details 🧪 

- Got this PearAI-Dev version from Nang for `darwin-x86` https://drive.google.com/file/d/1YHUXNZfW5ZyGmYxcjCsRKvlqoEmnhvvC/view?usp=sharing
- With that, I needed to be on node `v22.13.1` for some reason. If not, `./scripts/install-and-build.sh` would not succeed
- From play button run task / launch config `Extension (VSCode)`
- Added another command for `startOnboarding` since my local was slow and sometimes `Reset Onboarding` wasn't enough.

## Checklist ✅

- [x] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make VSCode settings import synchronous with error handling and retry logic, and update UI to reflect import status.
> 
>   - **Behavior**:
>     - Make VSCode settings import synchronous in `importUserSettingsFromVSCode()` in `copySettings.ts`.
>     - Add error handling and retry logic in `ImportExtensions.tsx`.
>     - Show skip button, hide for 5 seconds, then show again in `ImportExtensions.tsx`.
>     - Ensure process can be skipped or retried in `ImportExtensions.tsx`.
>   - **Commands**:
>     - Add `pearai.startOnboarding` command in `package.json` and `commands.ts`.
>     - Modify `pearai.welcome.importUserSettingsFromVSCode` to return a boolean in `commands.ts`.
>   - **Local Storage**:
>     - Add `isDoneImportingUserSettingsFromVSCode` to `localStorage.ts`.
>   - **UI**:
>     - Update `FinalStep.tsx` and `ImportExtensions.tsx` to handle import completion and errors.
>     - Adjust UI elements to reflect import status in `ImportExtensions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for fdc07464f828c8745d490ad0be546360a863f314. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->