### PR TITLE
set default location to auxbar

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -605,7 +605,7 @@
       ]
     },
     "viewsContainers": {
-      "activitybar": [
+      "auxiliarybar": [
         {
           "id": "PearAI",
           "title": "PearAI Chat",

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -123,7 +123,7 @@ const setupPearAPPLayout = async (context: vscode.ExtensionContext) => {
 
   if (isFirstLaunch(context)) {
     // move pearai extension to auxiliary bar (secondary side bar) if there is a folder open
-    vscode.commands.executeCommand("workbench.action.movePearExtensionToAuxBar");
+    // vscode.commands.executeCommand("workbench.action.movePearExtensionToAuxBar");
     // set activity bar position to top
     vscode.commands.executeCommand("workbench.action.activityBarLocation.top");
   }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default location of PearAI extension to auxiliary bar in VSCode extension.
> 
>   - **Behavior**:
>     - Change default location of PearAI extension from `activitybar` to `auxiliarybar` in `package.json`.
>     - Comment out `movePearExtensionToAuxBar` command in `setupPearAPPLayout()` in `activate.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 9c5feec1b389e441a179390b5e2358ca3fa9c00b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->