### PR TITLE
Added activation sidebar on left

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -24,6 +24,19 @@ export async function attemptInstallExtension(extensionId: string): Promise<void
   }
 
   try {
+    await vscode.workspace.getConfiguration().update('workbench.sideBar.location', 'left', true);
+    // Get auxiliary bar visibility state
+    const pearAIVisible = vscode.workspace.getConfiguration().get('workbench.auxiliaryBar.visible');
+
+    // Show auxiliary bar if it's not already visible
+    if (!pearAIVisible) {
+        await vscode.commands.executeCommand('workbench.action.toggleAuxiliaryBar');
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  try {
       await vscode.commands.executeCommand('workbench.extensions.installExtension', extensionId);
       // vscode.window.showInformationMessage(`Successfully installed extension: ${extensionId}`);
   } catch (error) {

--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -24,19 +24,6 @@ export async function attemptInstallExtension(extensionId: string): Promise<void
   }
 
   try {
-    await vscode.workspace.getConfiguration().update('workbench.sideBar.location', 'left', true);
-    // Get auxiliary bar visibility state
-    const pearAIVisible = vscode.workspace.getConfiguration().get('workbench.auxiliaryBar.visible');
-
-    // Show auxiliary bar if it's not already visible
-    if (!pearAIVisible) {
-        await vscode.commands.executeCommand('workbench.action.toggleAuxiliaryBar');
-    }
-  } catch (error) {
-    console.error(error);
-  }
-
-  try {
       await vscode.commands.executeCommand('workbench.extensions.installExtension', extensionId);
       // vscode.window.showInformationMessage(`Successfully installed extension: ${extensionId}`);
   } catch (error) {
@@ -99,6 +86,7 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
   // vscode.commands.executeCommand("pearai.focusContinueInput");
 
+
   // Load PearAI configuration
   if (!context.globalState.get("hasBeenInstalled")) {
     context.globalState.update("hasBeenInstalled", true);
@@ -109,6 +97,26 @@ export async function activateExtension(context: vscode.ExtensionContext) {
       },
       true,
     );
+  }
+
+  try {
+    await vscode.workspace.getConfiguration().update('workbench.sideBar.location', 'left', true);
+    // Get auxiliary bar visibility state
+    const pearAIVisible = vscode.workspace.getConfiguration().get('workbench.auxiliaryBar.visible');
+
+    // Show auxiliary bar if it's not already visible
+    if (!pearAIVisible) {
+        await vscode.commands.executeCommand('workbench.action.toggleAuxiliaryBar');
+    }
+  } catch (error) {
+    console.dir(error);
+  }
+
+  try {
+    vscode.commands.executeCommand("pearai.focusContinueInput");
+  } catch (error) {
+    // vscode.window.showErrorMessage(`Failed to install extension: ${extensionId}`);
+    console.error(error);
   }
 
   const api = new VsCodeContinueApi(vscodeExtension);


### PR DESCRIPTION
## Description ✏️

Closes #xxx

What changed? Feel free to be brief.

- Bullet points are helpful.
- Screenshots are helpful (if applicable).

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [ ] I have done a self-review of my code.
- [ ] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances VSCode extension activation by configuring sidebar settings, handling command execution errors, and setting up layout in `activate.ts`.
> 
>   - **Behavior**:
>     - Updates sidebar location to 'left' and ensures auxiliary bar visibility in `activateExtension()`.
>     - Executes `pearai.focusContinueInput` command with error handling in `activateExtension()`.
>   - **Functions**:
>     - Adds `setupPearAppLayout()` to configure layout settings, including moving views to auxiliary bar and setting activity bar position.
>   - **Error Handling**:
>     - Adds try-catch blocks for sidebar configuration and command execution in `activateExtension()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 1d15f0713c28b1cf5852ae125ddd07d8c2ead96a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->