### PR TITLE
force-new-onboarding-for-old-users

### DIFF
--- a/extensions/vscode/src/copySettings.ts
+++ b/extensions/vscode/src/copySettings.ts
@@ -3,7 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from "vscode";
 
-export const FIRST_LAUNCH_KEY = 'pearai.firstLaunch';
+export const FIRST_LAUNCH_KEY = 'pearai.firstLaunchKeyV2';
 const pearAISettingsDir = path.join(os.homedir(), '.pearai');
 const pearAIDevExtensionsDir = path.join(os.homedir(), '.pearai', 'extensions');
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `FIRST_LAUNCH_KEY` to `FIRST_LAUNCH_KEY_V2` in `copySettings.ts` to force new onboarding for old users and removes file-based flag migration logic.
> 
>   - **Behavior**:
>     - Renames `FIRST_LAUNCH_KEY` to `FIRST_LAUNCH_KEY_V2` in `copySettings.ts` to force new onboarding for old users.
>   - **Misc**:
>     - Removes file-based flag migration logic in `isFirstLaunch()` in `copySettings.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 7c3e49da7de5b39b43535a37d7a10cfadfa5b3f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->