### PR TITLE
fix length chat warning not showing

### DIFF
--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -61,7 +61,7 @@ import { getLogoPath } from "./welcome/setup/ImportExtensions";
 import { Badge } from "../components/ui/badge";
 import { cn } from "@/lib/utils";
 
-const LENGTHY_MESSAGE_WARNING_INDEX = 14; // number of messages after which we show the warning card
+const LENGTHY_MESSAGE_WARNING_INDEX = 15; // number of messages after which we show the warning card
 
 export const TopGuiDiv = styled.div<{ isNewSession: boolean }>`
   overflow-y: scroll;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjusts `LENGTHY_MESSAGE_WARNING_INDEX` in `gui.tsx` to change when the lengthy message warning is shown.
> 
>   - **Behavior**:
>     - Adjusts `LENGTHY_MESSAGE_WARNING_INDEX` from 14 to 15 in `gui.tsx`, changing when the lengthy message warning card is displayed in the chat interface.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for a0564911cd67d901421a42f18011377b823f334b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->