### PR TITLE
remove chat box border

### DIFF
--- a/gui/src/components/mainInput/ContinueInputBox.tsx
+++ b/gui/src/components/mainInput/ContinueInputBox.tsx
@@ -54,7 +54,6 @@ const GradientBorder = styled.div<{
   flex-direction: row;
   align-items: center;
   position: relative;
-  border: ${(props) => (!props.loading && props.isMainInput ? `2px solid ${vscInputBorder}` : "")};
   box-shadow: ${(props) => (!props.loading && props.isMainInput ? "0px 0px 20px 0px rgba(0, 0, 0, 0.50)" : "")};
 `;
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove border style from `GradientBorder` in `ContinueInputBox.tsx` when not loading and is main input.
> 
>   - **Visual Changes**:
>     - Removed border style from `GradientBorder` in `ContinueInputBox.tsx` when not loading and is main input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for f463e7584fc6ebc5ccc22a0209b2299313739b99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->