### PR TITLE
Set sidebar location when no preference

### DIFF
--- a/extensions/vscode/src/activation/activate.ts
+++ b/extensions/vscode/src/activation/activate.ts
@@ -108,7 +108,13 @@ export async function activateExtension(context: vscode.ExtensionContext) {
 
   // Force PearAI view mode
   try {
-    await vscode.workspace.getConfiguration().update('workbench.sideBar.location', 'left', true);
+    const sidebar = vscode.workspace.getConfiguration().inspect("workbench.sideBar.location");
+    
+    // If the user has not set the sidebar location set it
+    if (!sidebar?.globalValue) {
+      await vscode.workspace.getConfiguration().update("workbench.sideBar.location", "left", true);
+    }
+
     // Get auxiliary bar visibility state
     const pearAIVisible = vscode.workspace.getConfiguration().get('workbench.auxiliaryBar.visible');
 


### PR DESCRIPTION
## Description ✏️
In a recent change the sidebar location was being override on extension mount. This PR changes this logic to only set the sidebar location if the user has not set it already.

If the indented change was to force a "default layout" I would suggest creating some setting within the PearAI configuration, or include some flag that overrides this behavior.

## Checklist ✅

- [ ] I have added screenshots (if UI changes are present).
- [x] I have done a self-review of my code.
- [x] I have manually tested my code (if applicable).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `activateExtension` in `activate.ts` to set sidebar location only if not user-defined.
> 
>   - **Behavior**:
>     - In `activate.ts`, `activateExtension` now sets `workbench.sideBar.location` to 'left' only if not already set by the user.
>   - **Misc**:
>     - Suggests creating a setting or flag for default layout enforcement in PearAI configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for c6e95e37c3a23f100b026e910130f327a17695df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->