### PR TITLE
remove-add-to-context-keybinding

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -430,11 +430,6 @@
         "key": "ctrl+4"
       },
       {
-        "command": "pearai.focusContinueInput",
-        "mac": "cmd+l",
-        "key": "ctrl+l"
-      },
-      {
         "command": "pearai.focusContinueInputWithoutClear",
         "mac": "cmd+shift+l",
         "key": "ctrl+shift+l"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove keybinding for `pearai.focusContinueInput` in `package.json`.
> 
>   - **Keybindings**:
>     - Removed keybinding for `pearai.focusContinueInput` ("cmd+l" on Mac, "ctrl+l" on Windows/Linux) in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for afc96824cc7ee5237810f6502bbd1d88532447ed. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->