### PR TITLE
Fix padding bug + add space for new chats too

### DIFF
--- a/gui/src/pages/gui.tsx
+++ b/gui/src/pages/gui.tsx
@@ -233,7 +233,7 @@ function GUI() {
       if (inputContainerRef.current && topGuiDivRef.current) {
         const scrollTop = topGuiDivRef.current.scrollTop;
         const height = inputContainerRef.current.offsetHeight;
-        const newPadding = isNewSession ? '0px' : `${height + 20}px`;
+        const newPadding = `${height + 20}px`;
 
         topGuiDivRef.current.style.paddingBottom = '0px';
         topGuiDivRef.current.offsetHeight;
@@ -372,8 +372,9 @@ function GUI() {
     [state.history],
   );
 
-  const adjustPadding = useCallback((height: number) => {
-    if (topGuiDivRef.current) {
+  const adjustPadding = useCallback(() => {
+    if (inputContainerRef.current && topGuiDivRef.current) {
+      const height = inputContainerRef.current.offsetHeight;
       topGuiDivRef.current.style.paddingBottom = `${height + 20}px`;
     }
   }, []);


### PR DESCRIPTION
Sometimes the padding of chat content would be wrong and look like this (input container is on top of the text):
![Screenshot 2025-04-12 at 7 04 59 PM](https://github.com/user-attachments/assets/4f30e5d6-b324-4218-95da-776d4685067c)
Also during first message of new chats, output would be covered by cancel button.
![Screenshot 2025-04-12 at 5 40 52 PM](https://github.com/user-attachments/assets/6030a5be-603f-47c2-a7c2-24594daf6f5d)

Ts pmo 😜👺👺😿😿😿
This fixes both issues, now they always look normal!

![Screenshot 2025-04-12 at 5 46 00 PM](https://github.com/user-attachments/assets/8c795c45-91cc-4cfe-9c35-8bed14304feb)
Couldn't get a screenshot of second fix (it's just how it normally looks)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes chat padding and cancel button coverage issues in `GUI()` by adjusting padding logic in `gui.tsx`.
> 
>   - **Behavior**:
>     - Fixes padding issue in `GUI()` by removing conditional padding logic for new sessions.
>     - Ensures cancel button does not cover first message in new chats by adjusting padding calculation.
>   - **Functions**:
>     - Updates `adjustPadding` in `gui.tsx` to calculate padding based on `inputContainerRef` height.
>     - Modifies `useEffect` for `ResizeObserver` to consistently apply padding adjustments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=trypear%2Fpearai-submodule&utm_source=github&utm_medium=referral)<sup> for 147e2e5e906b6df643baf572ab773cb1f689c41c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->